### PR TITLE
Update missing config message

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -126,7 +126,7 @@ load_config() {
   IP_VERSION=
 
   if [[ -z "${CONFIG:-}" ]]; then
-    echo "WARNNG: No main config file found, using defaults" >&2
+    echo "WARNING: No main config file found, using defaults" >&2
   elif [[ -f "${CONFIG}" ]]; then
     echo "# INFO: Using main config file ${CONFIG}"
     BASEDIR="$(dirname "${CONFIG}")"

--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -126,9 +126,7 @@ load_config() {
   IP_VERSION=
 
   if [[ -z "${CONFIG:-}" ]]; then
-    echo "#" >&2
-    echo "# !! WARNING !! No main config file found, using default config!" >&2
-    echo "#" >&2
+    echo "WARNNG: No main config file found, using defaults" >&2
   elif [[ -f "${CONFIG}" ]]; then
     echo "# INFO: Using main config file ${CONFIG}"
     BASEDIR="$(dirname "${CONFIG}")"


### PR DESCRIPTION
There is no need for this message to sound so scary. letsencrypt.sh runs fine with it's defaults. I'd even consider removing this warning entirely.
