### PR TITLE
Retry invalid challenge responses, limit retries to 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Parameters:
  --ipv4 (-4)                      Resolve names to IPv4 addresses only
  --ipv6 (-6)                      Resolve names to IPv6 addresses only
  --domain (-d) domain.tld         Use specified domain name(s) instead of domains.txt entry (one certificate!)
- --retries (-r) NUMBER            Retry invalid challenge responses,  set number of retries to NUMBER
+ --retry                          Retry invalid challenge responses a maximum of 5 times
  --keep-going (-g)                Keep going after encountering an error while creating/renewing multiple certificates in cron mode
  --force (-x)                     Force renew of certificate even if it is longer valid than value in RENEW_DAYS
  --no-lock (-n)                   Don't use lockfile (potentially dangerous!)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Parameters:
  --ipv4 (-4)                      Resolve names to IPv4 addresses only
  --ipv6 (-6)                      Resolve names to IPv6 addresses only
  --domain (-d) domain.tld         Use specified domain name(s) instead of domains.txt entry (one certificate!)
+ --retries (-r) NUMBER            Retry invalid challenge responses,  set number of retries to NUMBER
  --keep-going (-g)                Keep going after encountering an error while creating/renewing multiple certificates in cron mode
  --force (-x)                     Force renew of certificate even if it is longer valid than value in RENEW_DAYS
  --no-lock (-n)                   Don't use lockfile (potentially dangerous!)


### PR DESCRIPTION
Coded to your coding standards, shellchecked

This will allow for the challenge to be retied for upto 5 times when it fails (returns invalid)

Allot of our servers are via cdn/load-balancers and they do not always sync quick enough, so will fail the first X attempts.

This also allows your script to have resiliency with bad connections/timeouts.

letsencrypt.sh --cron --force --retry

```
Processing test.extremeshok.com
 + Checking domain name(s) of existing cert... unchanged.
 + Checking expire date of existing cert...
 + Valid till Nov 19 22:26:00 2016 GMT (Longer than 30 days). Ignoring because renew was forced!
 + Signing domains...
 + Generating private key...
 + Generating signing request...
 + Requesting challenge for test.extremeshok.com...
 + Responding to challenge for test.extremeshok.com...attempt: 1
 + Invalid
 + Requesting challenge for test.extremeshok.com...
 + Responding to challenge for test.extremeshok.com...attempt: 2
 + Challenge is valid!
 + Requesting certificate...
 + Checking certificate...
 + Done!
 + Creating fullchain.pem...
 + Done!
```

Update to pull : https://github.com/lukas2511/letsencrypt.sh/pull/261

Retries reduce the load.

Here is the specific use case:

All 1000+ servers/vm's are managed/setup by idempotent configuration management. Spanning multiple data centers and countries.

We run a single node aka ssl.domain.com which is responsible for all ssl deployments for all the servers. ie. All "/.well-known/acme-challenge/" http requests from all the 1000+ servers are proxied to the ssl.domain.com server.

Under real world situations on production servers there are timeouts for the length the proxy request can take. Letsencrypt also has timeouts for the validation response. So fact is they can and will fail to validate because they timed out.

Letsencrypt does and will rate limit the number for validation attempts for a domain, so it provides no more load than the current script. Also if you look at the code, I specifically slow down the retries by adding a random 1-10 second pause between each retry.

I can understand your issue with someone setting 99999 retries, but this is virtually no different to them running the script 99999 times in a loop until the certificate has generated. The major difference is the retries will have a far lower impact on the lets encrypt servers.

Currently: If you are creating a certificate with 20 sub-domains and only one of the 20 sub-domains fails (ie number 19) validation, you are forced to rerun the script and re-validate all the sub-domains which were already validated. Thus you increased the load 18 more times.

With my retries only the failed validation will be retried, thus you only have 1 extra validation.

If you are concerned with the user setting a limit of 99999, I have limited the retries to 5.

In real world production all are verified by the 3rd attempt.

As to the proposed add a hook script, there is no place in the code for a hook after the json verification has been generated and before the verification has been validated.

Not to mention the limitation with the hook scripts as they cant do retries for a timeout. 
