### PR TITLE
Fix config logic for revoke command.

### DIFF
--- a/letsencrypt.sh
+++ b/letsencrypt.sh
@@ -77,6 +77,9 @@ reset_configvars() {
 
 # verify configuration values
 verify_config() {
+  if [[ "${COMMAND}" = "revoke" ]]; then
+    return
+  fi
   [[ "${CHALLENGETYPE}" =~ (http-01|dns-01) ]] || _exiterr "Unknown challenge type ${CHALLENGETYPE}... can not continue."
   if [[ "${CHALLENGETYPE}" = "dns-01" ]] && [[ -z "${HOOK}" ]]; then
     _exiterr "Challenge type dns-01 needs a hook script for deployment... can not continue."


### PR DESCRIPTION
I noticed that when I wanted to revoke a certificate it would complain about either not having a .well-known directory to perform a http challenge. Using dns-01 it would say there isn't a hook given. Neither of these are required to revoke a certificate so for the config check it should short circuit out of the method.
