### PR TITLE
Adding the invalid_challenge hook

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -533,7 +533,7 @@ sign_csr() {
     if [[ "${reqstatus}" = "valid" ]]; then
       echo " + Challenge is valid!"
     else
-      break
+      [[ -n "${HOOK}" ]] && [[ "${HOOK_CHAIN}" != "yes" ]] && "${HOOK}" "invalid_challenge" "${altname}" "${result}"
     fi
   done
 

--- a/docs/dns-verification.md
+++ b/docs/dns-verification.md
@@ -4,7 +4,7 @@ This script also supports the new `dns-01`-type verification. This type of verif
 
 You need a hook script that deploys the challenge to your DNS server!
 
-The hook script (indicated in the config file or the --hook/-k command line argument) gets four arguments: an operation name (clean_challenge, deploy_challenge, or deploy_cert) and some operands for that. For deploy_challenge $2 is the domain name for which the certificate is required, $3 is a "challenge token" (which is not needed for dns-01), and $4 is a token which needs to be inserted in a TXT record for the domain.
+The hook script (indicated in the config file or the --hook/-k command line argument) gets four arguments: an operation name (clean_challenge, deploy_challenge, deploy_cert or invalid_challenge) and some operands for that. For deploy_challenge $2 is the domain name for which the certificate is required, $3 is a "challenge token" (which is not needed for dns-01), and $4 is a token which needs to be inserted in a TXT record for the domain.
 
 Typically, you will need to split the subdomain name in two, the subdomain name and the domain name separately. For example, for "my.example.com", you'll need "my" and "example.com" separately. You then have to prefix "_acme-challenge." before the subdomain name, as in "_acme-challenge.my" and set a TXT record for that on the domain (e.g. "example.com") which has the value supplied in $4
 

--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -74,4 +74,18 @@ function unchanged_cert {
     #   The path of the file containing the intermediate certificate(s).
 }
 
+function invalid_challenge {
+    local DOMAIN="${1}" RESPONSE="${2}"
+
+    # This hook is called if the challenge response has failed, so domain
+    # owners can be aware and act accordingly.
+    #
+    # Parameters:
+    # - DOMAIN
+    #   The primary domain name, i.e. the certificate common
+    #   name (CN).
+    # - RESPONSE
+    #   The response that the verification server returned
+}
+
 HANDLER=$1; shift; $HANDLER $@


### PR DESCRIPTION
This hook is called if the challenge response has failed, so domain owners can be aware and act accordingly.
