### PR TITLE
Fix request new certificate if authorization valid

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -463,6 +463,8 @@ sign_csr() {
     if [[ $response == *"\"status\": \"valid\""* ]]; then
       already_valid[${idx}]=true
       continue
+    else
+      already_valid[${idx}]=false
     fi
 
     challenges="$(printf '%s\n' "${response}" | sed -n 's/.*\("challenges":[^\[]*\[.*}\s*]\).*/\1/p')"

--- a/dehydrated
+++ b/dehydrated
@@ -450,9 +450,9 @@ sign_csr() {
 
   local idx=0
   if [[ -n "${ZSH_VERSION:-}" ]]; then
-    local -A challenge_uris challenge_tokens keyauths deploy_args
+    local -A challenge_uris challenge_tokens keyauths deploy_args already_valid
   else
-    local -a challenge_uris challenge_tokens keyauths deploy_args
+    local -a challenge_uris challenge_tokens keyauths deploy_args already_valid
   fi
 
   # Request challenges
@@ -460,8 +460,12 @@ sign_csr() {
     # Ask the acme-server for new challenge token and extract them from the resulting json block
     echo " + Requesting challenge for ${altname}..."
     response="$(signed_request "${CA_NEW_AUTHZ}" '{"resource": "new-authz", "identifier": {"type": "dns", "value": "'"${altname}"'"}}' | clean_json)"
+    if [[ $response == *"\"status\": \"valid\""* ]]; then
+      already_valid[${idx}]=true
+      continue
+    fi
 
-    challenges="$(printf '%s\n' "${response}" | sed -n 's/.*\("challenges":[^\[]*\[[^]]*]\).*/\1/p')"
+    challenges="$(printf '%s\n' "${response}" | sed -n 's/.*\("challenges":[^\[]*\[.*}\s*]\).*/\1/p')"
     repl=$'\n''{' # fix syntax highlighting in Vim
     challenge="$(printf "%s" "${challenges//\{/${repl}}" | grep \""${CHALLENGETYPE}"\")"
     challenge_token="$(printf '%s' "${challenge}" | get_json_string_value token | _sed 's/[^A-Za-z0-9_\-]/_/g')"
@@ -502,6 +506,11 @@ sign_csr() {
   # Respond to challenges
   idx=0
   for altname in ${altnames}; do
+    if [ "${already_valid[${idx}]}" = true ]; then
+      echo " + No challenge required for ${altname} (skipping)"
+      reqstatus="valid"
+      continue
+    fi
     challenge_token="${challenge_tokens[${idx}]}"
     keyauth="${keyauths[${idx}]}"
 


### PR DESCRIPTION
I just had an issue after switching from dns based challenges to http (see [serverfault](https://serverfault.com/questions/804030/letsencrypt-certificate-renewal-switching-from-dns-to-http) and [le-community](https://community.letsencrypt.org/t/certificate-renewal-switching-from-dns-to-http/20030?u=dennisschuerholz)) so I made this quick fix which allowed me to use dehydrated again.

The change in Line 464(old)/468(new) corresponds to the "bigger" answer as mentioned in the serverfault post. Indeed it may not longer be necessary as I implemented a "quick escape" before extracting the challenges but I would leave it there - just in case.