### PR TITLE
Add new parameter --lock-suffix.

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -183,7 +183,7 @@ load_config() {
   [[ -z "${DOMAINS_TXT}" ]] && DOMAINS_TXT="${BASEDIR}/domains.txt"
   [[ -z "${WELLKNOWN}" ]] && WELLKNOWN="/var/www/dehydrated"
   [[ -z "${LOCKFILE}" ]] && LOCKFILE="${BASEDIR}/lock"
-  [[ -n "${PARAM_LOCKFILE_SUFFIX}" ]] && LOCKFILE="${LOCKFILE}-${PARAM_LOCKFILE_SUFFIX}"
+  [[ -n "${PARAM_LOCKFILE_SUFFIX:-}" ]] && LOCKFILE="${LOCKFILE}-${PARAM_LOCKFILE_SUFFIX}"
   [[ -n "${PARAM_NO_LOCK:-}" ]] && LOCKFILE=""
 
   [[ -n "${PARAM_HOOK:-}" ]] && HOOK="${PARAM_HOOK}"
@@ -1039,7 +1039,7 @@ main() {
         PARAM_NO_LOCK="yes"
         ;;
 
-      # PARAM_Usage: --lock-suffix
+      # PARAM_Usage: --lock-suffix example.com
       # PARAM_Description: Suffix lockfile name with a string (useful for with -d)
       --lock-suffix)
       	shift 1

--- a/dehydrated
+++ b/dehydrated
@@ -183,6 +183,7 @@ load_config() {
   [[ -z "${DOMAINS_TXT}" ]] && DOMAINS_TXT="${BASEDIR}/domains.txt"
   [[ -z "${WELLKNOWN}" ]] && WELLKNOWN="/var/www/dehydrated"
   [[ -z "${LOCKFILE}" ]] && LOCKFILE="${BASEDIR}/lock"
+  [[ -n "${PARAM_LOCKFILE_SUFFIX}" ]] && LOCKFILE="${LOCKFILE}-${PARAM_LOCKFILE_SUFFIX}"
   [[ -n "${PARAM_NO_LOCK:-}" ]] && LOCKFILE=""
 
   [[ -n "${PARAM_HOOK:-}" ]] && HOOK="${PARAM_HOOK}"
@@ -1036,6 +1037,14 @@ main() {
       # PARAM_Description: Don't use lockfile (potentially dangerous!)
       --no-lock|-n)
         PARAM_NO_LOCK="yes"
+        ;;
+
+      # PARAM_Usage: --lock-suffix
+      # PARAM_Description: Suffix lockfile name with a string (useful for with -d)
+      --lock-suffix)
+      	shift 1
+        check_parameters "${1:-}"
+	PARAM_LOCKFILE_SUFFIX="${1}"
         ;;
 
       # PARAM_Usage: --ocsp


### PR DESCRIPTION
This enables automation systems to run multiple instances of dehydrated
while still maintaining a locking facility. This is necessary for
projects like https://github.com/GUI/lua-resty-auto-ssl.

With this feature, one could run the script multiple times, while still
having a form of locking:

./dehydrated --lock-suffix test1.example.com -d test1.example.com
./dehydrated --lock-suffix test2.example.com -d test2.example.com
./dehydrated --lock-suffix test3.example.com -d test3.example.com
./dehydrated --lock-suffix test4.example.com -d test4.example.com
./dehydrated --lock-suffix test5.example.com -d test5.example.com

When starts the script with the same locking suffix, the scripts exits
like it normally would when locked. This will give you the benefits of
using --no-lock, without the disadvantages of it.
