### PR TITLE
Dockerfile: Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --update \
     openssl \
     && rm -rf /var/cache/apk/*
 
+WORKDIR dehydrated
 COPY . .
 
 ENTRYPOINT ["bash", "dehydrated"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+RUN apk add --update \
+    bash \
+    curl \
+    openssl \
+    && rm -rf /var/cache/apk/*
+
+COPY . .
+
+ENTRYPOINT ["bash", "dehydrated"]


### PR DESCRIPTION
Adds the necessary dependencies and files to a Dockerfile so the dehydrated script can be run inside a container.