### PR TITLE
Basic implementation for private key rollover

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -601,15 +601,14 @@ sign_domain() {
   if [[  -r "${CERTDIR}/${domain}/privkey.roll.pem" && ! -r "${CERTDIR}/${domain}/privkey-${timestamp}.pem" ]]; then
     echo " + Moving Rolloverkey into position.... "
     privkey="privkey-${timestamp}.pem"
-    cp -L "${CERTDIR}/${domain}/privkey.roll.pem" "${CERTDIR}/${domain}/privkey-${timestamp}.pem"
-    rm -f "${CERTDIR}/${domain}/privkey.roll.pem"
+    mv "${CERTDIR}/${domain}/privkey.roll.pem" "${CERTDIR}/${domain}/privkey-${timestamp}.pem"
   fi
   # generate a new private rollover key if we need or want one
   if [[ ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] && [[ "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
     echo " + Generating private rollover key..."
     case "${KEY_ALGO}" in
-      rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey-${timestamp}.roll.pem" "${KEYSIZE}";;
-      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${CERTDIR}/${domain}/privkey-${timestamp}.roll.pem";;
+      rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey.roll.pem" "${KEYSIZE}";;
+      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${CERTDIR}/${domain}/privkey.roll.pem";;
     esac
   fi
 
@@ -649,7 +648,6 @@ sign_domain() {
 
   # Update symlinks
   [[ "${privkey}" = "privkey.pem" ]] || ln -sf "privkey-${timestamp}.pem" "${CERTDIR}/${domain}/privkey.pem"
-  [[ "${PRIVATE_KEY_ROLLOVER}" = "yes" ]] && ln -sf "privkey-${timestamp}.roll.pem" "${CERTDIR}/${domain}/privkey.roll.pem"
 
   ln -sf "chain-${timestamp}.pem" "${CERTDIR}/${domain}/chain.pem"
   ln -sf "fullchain-${timestamp}.pem" "${CERTDIR}/${domain}/fullchain.pem"

--- a/dehydrated
+++ b/dehydrated
@@ -589,7 +589,7 @@ sign_domain() {
 
   privkey="privkey.pem"
   # generate a new private key if we need or want one
-  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" -a ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" -a "${CERTDIR}/${domain}/privkey.roll.pem" ]] ; then
+  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" && ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" && ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] ; then
     echo " + Generating private key..."
     privkey="privkey-${timestamp}.pem"
     case "${KEY_ALGO}" in
@@ -598,7 +598,7 @@ sign_domain() {
     esac
   fi
   # move rolloverkey into position (if any)
-  if [[  -r "${CERTDIR}/${domain}/privkey.roll.pem" -a ! -r "${CERTDIR}/${domain}/privkey-${timestamp}.pem" ]]; then
+  if [[  -r "${CERTDIR}/${domain}/privkey.roll.pem" && ! -r "${CERTDIR}/${domain}/privkey-${timestamp}.pem" ]]; then
     echo " + Moving Rolloverkey into position.... "
     privkey="privkey-${timestamp}.pem"
     cp -L "${CERTDIR}/${domain}/privkey.roll.pem" "${CERTDIR}/${domain}/privkey-${timestamp}.pem"

--- a/dehydrated
+++ b/dehydrated
@@ -589,7 +589,7 @@ sign_domain() {
 
   privkey="privkey.pem"
   # generate a new private key if we need or want one
-  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" && ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" && ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] ; then
+  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" ]] ; then
     echo " + Generating private key..."
     privkey="privkey-${timestamp}.pem"
     case "${KEY_ALGO}" in
@@ -598,13 +598,14 @@ sign_domain() {
     esac
   fi
   # move rolloverkey into position (if any)
-  if [[  -r "${CERTDIR}/${domain}/privkey.roll.pem" && ! -r "${CERTDIR}/${domain}/privkey-${timestamp}.pem" ]]; then
-    echo " + Moving Rolloverkey into position.... "
-    privkey="privkey-${timestamp}.pem"
-    mv "${CERTDIR}/${domain}/privkey.roll.pem" "${CERTDIR}/${domain}/privkey-${timestamp}.pem"
+  if [[ -r "${CERTDIR}/${domain}/privkey.pem" && -r "${CERTDIR}/${domain}/privkey.roll.pem" && "${PRIVATE_KEY_RENEW}" = "yes" && "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
+    echo " + Moving Rolloverkey into position....  "
+    mv "${CERTDIR}/${domain}/privkey.roll.pem" "${CERTDIR}/${domain}/privkey-tmp.pem"
+    mv "${CERTDIR}/${domain}/privkey-${timestamp}.pem" "${CERTDIR}/${domain}/privkey.roll.pem"
+    mv "${CERTDIR}/${domain}/privkey-tmp.pem" "${CERTDIR}/${domain}/privkey-${timestamp}.pem"
   fi
   # generate a new private rollover key if we need or want one
-  if [[ ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] && [[ "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
+  if [[ ! -r "${CERTDIR}/${domain}/privkey.roll.pem" && "${PRIVATE_KEY_ROLLOVER}" = "yes" && "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
     echo " + Generating private rollover key..."
     case "${KEY_ALGO}" in
       rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey.roll.pem" "${KEYSIZE}";;

--- a/dehydrated
+++ b/dehydrated
@@ -589,7 +589,7 @@ sign_domain() {
 
   privkey="privkey.pem"
   # generate a new private key if we need or want one
-  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" ]] ; then
+  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
     echo " + Generating private key..."
     privkey="privkey-${timestamp}.pem"
     case "${KEY_ALGO}" in
@@ -611,6 +611,11 @@ sign_domain() {
       rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey.roll.pem" "${KEYSIZE}";;
       prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${CERTDIR}/${domain}/privkey.roll.pem";;
     esac
+  fi
+  # delete rolloverkeys if disabled
+  if [[ -r "${CERTDIR}/${domain}/privkey.roll.pem" && ! "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
+    echo " + Removing Rolloverkey (feature disabled)..."
+    rm -f "${CERTDIR}/${domain}/privkey.roll.pem"
   fi
 
   # Generate signing request config and the actual signing request

--- a/dehydrated
+++ b/dehydrated
@@ -118,6 +118,7 @@ load_config() {
   KEYSIZE="4096"
   WELLKNOWN=
   PRIVATE_KEY_RENEW="yes"
+  PRIVATE_KEY_ROLLOVER="no"
   KEY_ALGO=rsa
   OPENSSL_CNF="$(openssl version -d | cut -d\" -f2)/openssl.cnf"
   CONTACT_EMAIL=
@@ -588,12 +589,27 @@ sign_domain() {
 
   privkey="privkey.pem"
   # generate a new private key if we need or want one
-  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
+  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" -a ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" -a "${CERTDIR}/${domain}/privkey.roll.pem" ]] ; then
     echo " + Generating private key..."
     privkey="privkey-${timestamp}.pem"
     case "${KEY_ALGO}" in
       rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey-${timestamp}.pem" "${KEYSIZE}";;
       prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${CERTDIR}/${domain}/privkey-${timestamp}.pem";;
+    esac
+  fi
+  # move rolloverkey into position (if any)
+  if [[  -r "${CERTDIR}/${domain}/privkey.roll.pem" -a ! -r "${CERTDIR}/${domain}/privkey-${timestamp}.pem" ]]; then
+    echo " + Moving Rolloverkey into position.... "
+    privkey="privkey-${timestamp}.pem"
+    cp -L "${CERTDIR}/${domain}/privkey.roll.pem" "${CERTDIR}/${domain}/privkey-${timestamp}.pem"
+    rm -f "${CERTDIR}/${domain}/privkey.roll.pem"
+  fi
+  # generate a new private rollover key if we need or want one
+  if [[ ! -r "${CERTDIR}/${domain}/privkey.roll.pem" ]] && [[ "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
+    echo " + Generating private rollover key..."
+    case "${KEY_ALGO}" in
+      rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey-${timestamp}.roll.pem" "${KEYSIZE}";;
+      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${CERTDIR}/${domain}/privkey-${timestamp}.roll.pem";;
     esac
   fi
 
@@ -633,6 +649,7 @@ sign_domain() {
 
   # Update symlinks
   [[ "${privkey}" = "privkey.pem" ]] || ln -sf "privkey-${timestamp}.pem" "${CERTDIR}/${domain}/privkey.pem"
+  [[ "${PRIVATE_KEY_ROLLOVER}" = "yes" ]] && ln -sf "privkey-${timestamp}.roll.pem" "${CERTDIR}/${domain}/privkey.roll.pem"
 
   ln -sf "chain-${timestamp}.pem" "${CERTDIR}/${domain}/chain.pem"
   ln -sf "fullchain-${timestamp}.pem" "${CERTDIR}/${domain}/fullchain.pem"
@@ -709,7 +726,7 @@ command_sign_domains() {
         config_var="$(echo "${cfgline:1}" | cut -d'=' -f1)"
         config_value="$(echo "${cfgline:1}" | cut -d'=' -f2-)"
         case "${config_var}" in
-          KEY_ALGO|OCSP_MUST_STAPLE|PRIVATE_KEY_RENEW|KEYSIZE|CHALLENGETYPE|HOOK|WELLKNOWN|HOOK_CHAIN|OPENSSL_CNF|RENEW_DAYS)
+          KEY_ALGO|OCSP_MUST_STAPLE|PRIVATE_KEY_RENEW|PRIVATE_KEY_ROLLOVER|KEYSIZE|CHALLENGETYPE|HOOK|WELLKNOWN|HOOK_CHAIN|OPENSSL_CNF|RENEW_DAYS)
             echo "   + ${config_var} = ${config_value}"
             declare -- "${config_var}=${config_value}"
             ;;

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -72,6 +72,9 @@
 # Regenerate private keys instead of just signing new certificates on renewal (default: yes)
 #PRIVATE_KEY_RENEW="yes"
 
+# Create an extra private key for rollover (default: no)
+#PRIVATE_KEY_ROLLOVER="no"
+
 # Which public key algorithm should be used? Supported: rsa, prime256v1 and secp384r1
 #KEY_ALGO=rsa
 


### PR DESCRIPTION
Hi Lukas!

Implementation of private key rollover
Currently uses $PRIVATE_KEY_ROLLOVER, should work for per-cert config.
To use:
PRIVATE_KEY_RENEW=yes
PRIVATE_KEY_ROLLOVER=yes

An extra private key is created on the first run.
If a rolloverkey and a private key exists, it swaps both.
If PRIVATE_KEY_ROLLOVER is disabled, rollover keys are deleted.

No changes to HOOK-api.

Hacked some CI-tests, but untested.
They should:
a) request a cert, create a private key [A], create a rollover key [B].
b) request a cert (forced), create a private key [C], swap rollover key [B] with private key [C]
c) Check if SHA256 Hash matches with [B] (actual private key used on b) should match rollover key in a) )