### PR TITLE
fix lighttpd syntax

### DIFF
--- a/docs/wellknown.md
+++ b/docs/wellknown.md
@@ -60,9 +60,8 @@ Alias /.well-known/acme-challenge /var/www/dehydrated
 With Lighttpd just add this to your config and it should work in any VHost:
 
 ```lighttpd
-modules += "alias"
-
+server.modules += ("alias")
 alias.url += (
- "/.well-known/acme-challenge/" => "/var/www/dehydrated/"
+ "/.well-known/acme-challenge/" => "/var/www/dehydrated/",
 )
 ```


### PR DESCRIPTION
at least in 1.4 the syntax is `server.modules` and it's an array.
and it's always good idea to keep trailing comma to avoid syntax errors when adding new entries.