### PR TITLE
Fixing "$1 not set" for HANDLER var

### DIFF
--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -74,5 +74,7 @@ unchanged_cert() {
     #   The path of the file containing the intermediate certificate(s).
 }
 
-HANDLER="$1"; shift
-"$HANDLER" "$@"
+if [ "$#" -gt 0 ]; then
+    HANDLER="$1"; shift
+    "$HANDLER" "$@"
+fi


### PR DESCRIPTION
Just cloned your repository, configured config and all necessary files. 
Started a test with `dehydrated -f /etc/dehydrated/config -c` and got the following

```
root@domain:/etc/dehydrated# /opt/dehydrated/dehydrated -f /etc/dehydrated/config -c
# INFO: Using main config file /etc/dehydrated/config
# INFO: Using additional config file /etc/dehydrated/hook.sh
/etc/dehydrated/hook.sh: Zeile 77: $1 ist nicht gesetzt.
```

So it seems that the script is called without parameter and got this exception. So I added in my pull request a simple if-else-statement!