### PR TITLE
Fix: bash to sh notation on invalid_challenge() hook

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -366,6 +366,13 @@ http_request() {
     cat "${tempcont}" >&2
     echo >&2
     echo >&2
+
+    # An exclusive hook for the {1}-request error might be useful (e.g., for sending an e-mail to admins)
+    if [[ -n "${HOOK}" ]] && [[ "${HOOK_CHAIN}" != "yes" ]]; then
+      errtxt=`cat ${tempcont}`
+      "${HOOK}" "request_failure" "${statuscode}" "${errtxt}" "${1}"
+    fi
+
     rm -f "${tempcont}"
 
     # Wait for hook script to clean the challenge if used

--- a/docs/dns-verification.md
+++ b/docs/dns-verification.md
@@ -4,7 +4,7 @@ This script also supports the new `dns-01`-type verification. This type of verif
 
 You need a hook script that deploys the challenge to your DNS server!
 
-The hook script (indicated in the config file or the --hook/-k command line argument) gets four arguments: an operation name (clean_challenge, deploy_challenge, deploy_cert or invalid_challenge) and some operands for that. For deploy_challenge $2 is the domain name for which the certificate is required, $3 is a "challenge token" (which is not needed for dns-01), and $4 is a token which needs to be inserted in a TXT record for the domain.
+The hook script (indicated in the config file or the --hook/-k command line argument) gets four arguments: an operation name (clean_challenge, deploy_challenge, deploy_cert, invalid_challenge or request_failure) and some operands for that. For deploy_challenge $2 is the domain name for which the certificate is required, $3 is a "challenge token" (which is not needed for dns-01), and $4 is a token which needs to be inserted in a TXT record for the domain.
 
 Typically, you will need to split the subdomain name in two, the subdomain name and the domain name separately. For example, for "my.example.com", you'll need "my" and "example.com" separately. You then have to prefix "_acme-challenge." before the subdomain name, as in "_acme-challenge.my" and set a TXT record for that on the domain (e.g. "example.com") which has the value supplied in $4
 

--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -74,7 +74,7 @@ unchanged_cert() {
     #   The path of the file containing the intermediate certificate(s).
 }
 
-function invalid_challenge {
+invalid_challenge() {
     local DOMAIN="${1}" RESPONSE="${2}"
 
     # This hook is called if the challenge response has failed, so domain

--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -88,5 +88,22 @@ invalid_challenge() {
     #   The response that the verification server returned
 }
 
+request_failure() {
+    local STATUSCODE="${1}" REASON="${2}" REQTYPE=${3}
+
+    # This hook is called when a HTTP request fails (e.g., when the ACME
+    # server is busy, returns an error, etc). It will be called upon any
+    # response code that does not start with '2'. Useful to alert admins
+    # about problems with requests.
+    #
+    # Parameters:
+    # - STATUSCODE
+    #   The HTML status code that originated the error.
+    # - REASON
+    #   The specified reason for the error.
+    # - REQTYPE
+    #   The kind of request that was made (GET, POST...)
+}
+
 HANDLER="$1"; shift
 "$HANDLER" "$@"


### PR DESCRIPTION
The hook for invalid_challenge still had old notation from bash, I converted the bash notation to sh notation.