### PR TITLE
Changed a fatal to non-fatal to be able to continue parsing domains.t…

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -581,7 +581,10 @@ sign_csr() {
       done
     fi
 
-    _exiterr "Challenge is invalid! (returned: ${reqstatus}) (result: ${result})"
+     # Non-fatal exception if host cannot be reached as to be able to continue with other hosts in domains.txt
+     echo " !!! WARNING !!! Challenge is invalid! (returned: ${reqstatus}) (result: ${result}) "
+     echo " !!! WARNING !!! Certificate above will *NOT* be renewed/(created)! "
+     continue
   fi
 
   # Finally request certificate from the acme-server and store it in cert-${timestamp}.pem and link from cert.pem


### PR DESCRIPTION
…xt if a host experiences network issues. This could be done so much prettier but we needed something fastish as a single host in our domains.txt with reachability issues caused no further processing to happen. Hope this feature(ish) can get added even if this patch is ignored; then we can go back to using the main repo. Thanks.