### PR TITLE
Enable alternate domain file location

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1160,6 +1160,8 @@ main() {
          fi
         ;;
 
+      # PARAM_Usage: --domains-txt (-d) domains.txt
+      # PARAM_Description: Use alternate domains.txt file
       --domains-txt|-D)
         shift 1
         check_parameters "${1:-}"

--- a/dehydrated
+++ b/dehydrated
@@ -194,6 +194,7 @@ load_config() {
   [[ -n "${PARAM_KEY_ALGO:-}" ]] && KEY_ALGO="${PARAM_KEY_ALGO}"
   [[ -n "${PARAM_OCSP_MUST_STAPLE:-}" ]] && OCSP_MUST_STAPLE="${PARAM_OCSP_MUST_STAPLE}"
   [[ -n "${PARAM_IP_VERSION:-}" ]] && IP_VERSION="${PARAM_IP_VERSION}"
+  [[ -n "${PARAM_DOMAINS_TXT:+x}" ]] && DOMAINS_TXT="${PARAM_DOMAINS_TXT}" && echo "# INFO: using external domains file : ${DOMAINS_TXT}"
 
   verify_config
   store_configvars
@@ -1157,6 +1158,12 @@ main() {
         else
           PARAM_DOMAIN="${PARAM_DOMAIN} ${1}"
          fi
+        ;;
+
+      --domains-txt|-D)
+        shift 1
+        check_parameters "${1:-}"
+        PARAM_DOMAINS_TXT="${1}"
         ;;
 
       # PARAM_Usage: --keep-going (-g)

--- a/docs/systemd-timer.md
+++ b/docs/systemd-timer.md
@@ -1,0 +1,40 @@
+### Systemd timers
+
+##Separate certificate stores
+
+Situation: One server, one domain, multiple services.
+For example, let $SERVICE be one of : 
+- nginx 
+- postfix 
+- ejabberd
+
+Each service requires its own SSL certificate potentially with different parameters.
+
+Create the following folder(s):
+`/etc/ssl/$SERVICE/`
+
+
+each $SERVICE contains its own domains.txt, hooks.sh, and per domain certificate store.
+Now $SERVICE may depend on `letsencrypt@$SERVICE.timer` to automatically update its certificates by
+adding `Wants=letsencrypt@$SERVICE.timer` to the [UNIT] section.
+
+##Unit files
+#letsencrypt@.service
+```
+[Unit]
+Description=%I Let's Encrypt certificate checker
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/dehydrated --out /etc/ssl/%I --lock-suffix %I --hook /etc/ssl/%I/hook.sh -D /etc/ssl/%I/domains.txt -c
+```
+
+#letsencrypt@.timer
+```
+[Unit]
+Description=Refresh let's %I encrypt certificates
+
+[Timer]
+Persistent=true
+OnCalendar=monthly
+```


### PR DESCRIPTION
Usecase:Per service domains.txt.
For instance ejabberd and nginx need certificates for the same domain, but with different parameters. See systemd-usage.md how the -D parameter helps streamlining dehydrated usage.