### PR TITLE
Support older bash releases

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -77,14 +77,14 @@ reset_configvars() {
 
 # verify configuration values
 verify_config() {
-  [[ "${CHALLENGETYPE}" =~ (http-01|dns-01) ]] || _exiterr "Unknown challenge type ${CHALLENGETYPE}... can not continue."
+  [[ "${CHALLENGETYPE}" == "http-01" || "${CHALLENGETYPE}" == "dns-01" ]] || _exiterr "Unknown challenge type ${CHALLENGETYPE}... can not continue."
   if [[ "${CHALLENGETYPE}" = "dns-01" ]] && [[ -z "${HOOK}" ]]; then
     _exiterr "Challenge type dns-01 needs a hook script for deployment... can not continue."
   fi
   if [[ "${CHALLENGETYPE}" = "http-01" && ! -d "${WELLKNOWN}" && ! "${COMMAND:-}" = "register" ]]; then
     _exiterr "WELLKNOWN directory doesn't exist, please create ${WELLKNOWN} and set appropriate permissions."
   fi
-  [[ "${KEY_ALGO}" =~ ^(rsa|prime256v1|secp384r1)$ ]] || _exiterr "Unknown public key algorithm ${KEY_ALGO}... can not continue."
+  [[ "${KEY_ALGO}" == "rsa" || "${KEY_ALGO}" == "prime256v1" || "${KEY_ALGO}" == "secp384r1" ]] || _exiterr "Unknown public key algorithm ${KEY_ALGO}... can not continue."
   if [[ -n "${IP_VERSION}" ]]; then
     [[ "${IP_VERSION}" = "4" || "${IP_VERSION}" = "6" ]] || _exiterr "Unknown IP version ${IP_VERSION}... can not continue."
   fi
@@ -728,7 +728,7 @@ sign_domain() {
   echo " + Generating signing request..."
   SAN=""
   for altname in ${altnames}; do
-    SAN+="DNS:${altname}, "
+    SAN="${SAN}DNS:${altname}, "
   done
   SAN="${SAN%%, }"
   local tmp_openssl_cnf


### PR DESCRIPTION
Bash 3.0 and others seem to have serious issues running dehydrated.
https://github.com/lukas2511/dehydrated/issues/284 tracks the
problem but got closed as it seems too hard to support "stone age"
distributions.

Turns out it is actually only a three line change. ;-)