### PR TITLE
Ability to provide extra curl options

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -111,6 +111,7 @@ load_config() {
   ACCOUNTDIR=
   CHALLENGETYPE="http-01"
   CONFIG_D=
+  CURL_OPTS=
   DOMAINS_D=
   DOMAINS_TXT=
   HOOK=
@@ -370,13 +371,13 @@ http_request() {
 
   set +e
   if [[ "${1}" = "head" ]]; then
-    statuscode="$(curl ${ip_version:-} -s -w "%{http_code}" -o "${tempcont}" "${2}" -I)"
+    statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" "${2}" -I)"
     curlret="${?}"
   elif [[ "${1}" = "get" ]]; then
-    statuscode="$(curl ${ip_version:-} -s -w "%{http_code}" -o "${tempcont}" "${2}")"
+    statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" "${2}")"
     curlret="${?}"
   elif [[ "${1}" = "post" ]]; then
-    statuscode="$(curl ${ip_version:-} -s -w "%{http_code}" -o "${tempcont}" "${2}" -d "${3}")"
+    statuscode="$(curl ${ip_version:-} ${CURL_OPTS} -s -w "%{http_code}" -o "${tempcont}" "${2}" -d "${3}")"
     curlret="${?}"
   else
     set -e

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -54,6 +54,9 @@
 # Path to openssl config file (default: <unset> - tries to figure out system default)
 #OPENSSL_CNF=
 
+# Extra options passed to the curl binary (default: <unset>)
+#CURL_OPTS=
+
 # Program or function called in certain situations
 #
 # After generating the challenge-response, or after failed challenge (in this case altname is empty)


### PR DESCRIPTION
In some situations it might be necessary to pass extra commands to
the curl binary, e.g. proxy authentication credentials.

Adds the CURL_OPTS config option.