### PR TITLE
add cert alias, fixing #396

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ This file contains a log of major changes in dehydrated
 
 ## [x.x.x] - xxxx-xx-xx
 ## Changed
-- ...
+- domains.txt and the commandline "--domain" allows an alias name to be given by leading "--alias alias-name"
 
 ## [0.4.0] - 2017-02-05
 ## Changed

--- a/dehydrated
+++ b/dehydrated
@@ -678,16 +678,16 @@ walk_chain() {
 
 # Create certificate for domain(s)
 sign_domain() {
-  domain="${1}"
-  altnames="${*}"
+  local certdir="${1}"
+  shift
+  local primary="${1}"
+  local alldomains="${*}"
   timestamp="$(date +%s)"
 
   echo " + Signing domains..."
   if [[ -z "${CA_NEW_AUTHZ}" ]] || [[ -z "${CA_NEW_CERT}" ]]; then
     _exiterr "Certificate authority doesn't allow certificate signing"
   fi
-
-  local certdir="${CERTDIR}/${domain}"
 
   # If there is no existing certificate directory => make it
   if [[ ! -e "${certdir}" ]]; then
@@ -729,7 +729,7 @@ sign_domain() {
   # Generate signing request config and the actual signing request
   echo " + Generating signing request..."
   SAN=""
-  for altname in ${altnames}; do
+  for altname in ${alldomains}; do
     SAN+="DNS:${altname}, "
   done
   SAN="${SAN%%, }"
@@ -740,12 +740,12 @@ sign_domain() {
   if [ "${OCSP_MUST_STAPLE}" = "yes" ]; then
     printf "\n1.3.6.1.5.5.7.1.24=DER:30:03:02:01:05" >> "${tmp_openssl_cnf}"
   fi
-  openssl req -new -sha256 -key "${certdir}/${privkey}" -out "${certdir}/cert-${timestamp}.csr" -subj "/CN=${domain}/" -reqexts SAN -config "${tmp_openssl_cnf}"
+  openssl req -new -sha256 -key "${certdir}/${privkey}" -out "${certdir}/cert-${timestamp}.csr" -subj "/CN=${primary}/" -reqexts SAN -config "${tmp_openssl_cnf}"
   rm -f "${tmp_openssl_cnf}"
 
   crt_path="${certdir}/cert-${timestamp}.pem"
   # shellcheck disable=SC2086
-  sign_csr "$(< "${certdir}/cert-${timestamp}.csr" )" ${altnames} 3>"${crt_path}"
+  sign_csr "$(< "${certdir}/cert-${timestamp}.csr" )" ${alldomains} 3>"${crt_path}"
 
   # Create fullchain.pem
   echo " + Creating fullchain.pem..."
@@ -798,19 +798,20 @@ command_sign_domains() {
   for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' | (grep -vE '^(#|$)' || true)); do
     reset_configvars
     IFS="${ORIGIFS}"
-    domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
+    primary="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
     morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
+    alldomains="${primary} ${morenames}"
 
-    local certdir="${CERTDIR}/${domain}"
+    local certdir="${CERTDIR}/${primary}"
 
     cert="${certdir}/cert.pem"
 
     force_renew="${PARAM_FORCE:-no}"
 
     if [[ -z "${morenames}" ]];then
-      echo "Processing ${domain}"
+      echo "Processing ${primary}"
     else
-      echo "Processing ${domain} with alternative names: ${morenames}"
+      echo "Processing ${primary} with alternative names: ${morenames}"
     fi
 
     # read cert config
@@ -818,7 +819,7 @@ command_sign_domains() {
     # we could just source the config file but i decided to go this way to protect people from accidentally overriding
     # variables used internally by this script itself.
     if [[ -n "${DOMAINS_D}" ]]; then
-      certconfig="${DOMAINS_D}/${domain}"
+      certconfig="${DOMAINS_D}/${primary}"
     else
       certconfig="${certdir}/config"
     fi
@@ -858,7 +859,7 @@ command_sign_domains() {
       printf " + Checking domain name(s) of existing cert..."
 
       certnames="$(openssl x509 -in "${cert}" -text -noout | grep DNS: | _sed 's/DNS://g' | tr -d ' ' | tr ',' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//')"
-      givennames="$(echo "${domain}" "${morenames}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
+      givennames="$(echo "${alldomains}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
 
       if [[ "${certnames}" = "${givennames}" ]]; then
         echo " unchanged."
@@ -884,7 +885,7 @@ command_sign_domains() {
         else
           # Certificate-Names unchanged and cert is still valid
           echo "Skipping renew!"
-          [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem"
+          [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${primary}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem"
           continue
         fi
       else
@@ -894,10 +895,10 @@ command_sign_domains() {
 
     # shellcheck disable=SC2086
     if [[ "${PARAM_KEEP_GOING:-}" = "yes" ]]; then
-      sign_domain ${line} &
+      sign_domain "${certdir}" ${alldomains} &
       wait $! || true
     else
-      sign_domain ${line}
+      sign_domain "${certdir}" ${alldomains}
     fi
   done
 

--- a/dehydrated
+++ b/dehydrated
@@ -762,7 +762,7 @@ sign_domain() {
   ln -sf "cert-${timestamp}.pem" "${certdir}/cert.pem"
 
   # Wait for hook script to clean the challenge and to deploy cert if used
-  [[ -n "${HOOK}" ]] && "${HOOK}" "deploy_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem" "${timestamp}"
+  [[ -n "${HOOK}" ]] && "${HOOK}" "deploy_cert" "${primary}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem" "${timestamp}"
 
   unset challenge_token
   echo " + Done!"
@@ -798,28 +798,39 @@ command_sign_domains() {
   for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' | (grep -vE '^(#|$)' || true)); do
     reset_configvars
     IFS="${ORIGIFS}"
-    primary="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
-    morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
+    first_arg="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
+    if [[ ${first_arg} == "--alias" ]]; then
+      alias="$(printf '%s\n' "${line}" | cut -s -d' ' -f2)"
+      primary="$(printf '%s\n' "${line}" | cut -s -d' ' -f3)"
+      morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f4-)"
+    else
+      alias="${first_arg}"
+      primary="${first_arg}"
+      morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
+    fi
     alldomains="${primary} ${morenames}"
 
-    local certdir="${CERTDIR}/${primary}"
+    local certdir="${CERTDIR}/${alias}"
 
     cert="${certdir}/cert.pem"
 
     force_renew="${PARAM_FORCE:-no}"
 
-    if [[ -z "${morenames}" ]];then
-      echo "Processing ${primary}"
-    else
-      echo "Processing ${primary} with alternative names: ${morenames}"
+    echo -n "Processing ${primary}"
+    if [[ -n "${morenames}" ]];then
+      echo -n " with alternative names: ${morenames}"
     fi
+    if [[ "${alias}" != "${primary}" ]]; then
+      echo -n " with alias ${alias}"
+    fi
+    echo
 
     # read cert config
     # for now this loads the certificate specific config in a subshell and parses a diff of set variables.
     # we could just source the config file but i decided to go this way to protect people from accidentally overriding
     # variables used internally by this script itself.
     if [[ -n "${DOMAINS_D}" ]]; then
-      certconfig="${DOMAINS_D}/${primary}"
+      certconfig="${DOMAINS_D}/${alias}"
     else
       certconfig="${certdir}/config"
     fi

--- a/dehydrated
+++ b/dehydrated
@@ -687,41 +687,43 @@ sign_domain() {
     _exiterr "Certificate authority doesn't allow certificate signing"
   fi
 
+  local certdir="${CERTDIR}/${domain}"
+
   # If there is no existing certificate directory => make it
-  if [[ ! -e "${CERTDIR}/${domain}" ]]; then
-    echo " + Creating new directory ${CERTDIR}/${domain} ..."
-    mkdir -p "${CERTDIR}/${domain}" || _exiterr "Unable to create directory ${CERTDIR}/${domain}"
+  if [[ ! -e "${certdir}" ]]; then
+    echo " + Creating new directory ${certdir} ..."
+    mkdir -p "${certdir}" || _exiterr "Unable to create directory ${certdir}"
   fi
 
   privkey="privkey.pem"
   # generate a new private key if we need or want one
-  if [[ ! -r "${CERTDIR}/${domain}/privkey.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
+  if [[ ! -r "${certdir}/privkey.pem" ]] || [[ "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
     echo " + Generating private key..."
     privkey="privkey-${timestamp}.pem"
     case "${KEY_ALGO}" in
-      rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey-${timestamp}.pem" "${KEYSIZE}";;
-      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${CERTDIR}/${domain}/privkey-${timestamp}.pem";;
+      rsa) _openssl genrsa -out "${certdir}/privkey-${timestamp}.pem" "${KEYSIZE}";;
+      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${certdir}/privkey-${timestamp}.pem";;
     esac
   fi
   # move rolloverkey into position (if any)
-  if [[ -r "${CERTDIR}/${domain}/privkey.pem" && -r "${CERTDIR}/${domain}/privkey.roll.pem" && "${PRIVATE_KEY_RENEW}" = "yes" && "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
+  if [[ -r "${certdir}/privkey.pem" && -r "${certdir}/privkey.roll.pem" && "${PRIVATE_KEY_RENEW}" = "yes" && "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
     echo " + Moving Rolloverkey into position....  "
-    mv "${CERTDIR}/${domain}/privkey.roll.pem" "${CERTDIR}/${domain}/privkey-tmp.pem"
-    mv "${CERTDIR}/${domain}/privkey-${timestamp}.pem" "${CERTDIR}/${domain}/privkey.roll.pem"
-    mv "${CERTDIR}/${domain}/privkey-tmp.pem" "${CERTDIR}/${domain}/privkey-${timestamp}.pem"
+    mv "${certdir}/privkey.roll.pem" "${certdir}/privkey-tmp.pem"
+    mv "${certdir}/privkey-${timestamp}.pem" "${certdir}/privkey.roll.pem"
+    mv "${certdir}/privkey-tmp.pem" "${certdir}/privkey-${timestamp}.pem"
   fi
   # generate a new private rollover key if we need or want one
-  if [[ ! -r "${CERTDIR}/${domain}/privkey.roll.pem" && "${PRIVATE_KEY_ROLLOVER}" = "yes" && "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
+  if [[ ! -r "${certdir}/privkey.roll.pem" && "${PRIVATE_KEY_ROLLOVER}" = "yes" && "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
     echo " + Generating private rollover key..."
     case "${KEY_ALGO}" in
-      rsa) _openssl genrsa -out "${CERTDIR}/${domain}/privkey.roll.pem" "${KEYSIZE}";;
-      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${CERTDIR}/${domain}/privkey.roll.pem";;
+      rsa) _openssl genrsa -out "${certdir}/privkey.roll.pem" "${KEYSIZE}";;
+      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${certdir}/privkey.roll.pem";;
     esac
   fi
   # delete rolloverkeys if disabled
-  if [[ -r "${CERTDIR}/${domain}/privkey.roll.pem" && ! "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
+  if [[ -r "${certdir}/privkey.roll.pem" && ! "${PRIVATE_KEY_ROLLOVER}" = "yes" ]]; then
     echo " + Removing Rolloverkey (feature disabled)..."
-    rm -f "${CERTDIR}/${domain}/privkey.roll.pem"
+    rm -f "${certdir}/privkey.roll.pem"
   fi
 
   # Generate signing request config and the actual signing request
@@ -738,29 +740,29 @@ sign_domain() {
   if [ "${OCSP_MUST_STAPLE}" = "yes" ]; then
     printf "\n1.3.6.1.5.5.7.1.24=DER:30:03:02:01:05" >> "${tmp_openssl_cnf}"
   fi
-  openssl req -new -sha256 -key "${CERTDIR}/${domain}/${privkey}" -out "${CERTDIR}/${domain}/cert-${timestamp}.csr" -subj "/CN=${domain}/" -reqexts SAN -config "${tmp_openssl_cnf}"
+  openssl req -new -sha256 -key "${certdir}/${privkey}" -out "${certdir}/cert-${timestamp}.csr" -subj "/CN=${domain}/" -reqexts SAN -config "${tmp_openssl_cnf}"
   rm -f "${tmp_openssl_cnf}"
 
-  crt_path="${CERTDIR}/${domain}/cert-${timestamp}.pem"
+  crt_path="${certdir}/cert-${timestamp}.pem"
   # shellcheck disable=SC2086
-  sign_csr "$(< "${CERTDIR}/${domain}/cert-${timestamp}.csr" )" ${altnames} 3>"${crt_path}"
+  sign_csr "$(< "${certdir}/cert-${timestamp}.csr" )" ${altnames} 3>"${crt_path}"
 
   # Create fullchain.pem
   echo " + Creating fullchain.pem..."
-  cat "${crt_path}" > "${CERTDIR}/${domain}/fullchain-${timestamp}.pem"
-  walk_chain "${crt_path}" > "${CERTDIR}/${domain}/chain-${timestamp}.pem"
-  cat "${CERTDIR}/${domain}/chain-${timestamp}.pem" >> "${CERTDIR}/${domain}/fullchain-${timestamp}.pem"
+  cat "${crt_path}" > "${certdir}/fullchain-${timestamp}.pem"
+  walk_chain "${crt_path}" > "${certdir}/chain-${timestamp}.pem"
+  cat "${certdir}/chain-${timestamp}.pem" >> "${certdir}/fullchain-${timestamp}.pem"
 
   # Update symlinks
-  [[ "${privkey}" = "privkey.pem" ]] || ln -sf "privkey-${timestamp}.pem" "${CERTDIR}/${domain}/privkey.pem"
+  [[ "${privkey}" = "privkey.pem" ]] || ln -sf "privkey-${timestamp}.pem" "${certdir}/privkey.pem"
 
-  ln -sf "chain-${timestamp}.pem" "${CERTDIR}/${domain}/chain.pem"
-  ln -sf "fullchain-${timestamp}.pem" "${CERTDIR}/${domain}/fullchain.pem"
-  ln -sf "cert-${timestamp}.csr" "${CERTDIR}/${domain}/cert.csr"
-  ln -sf "cert-${timestamp}.pem" "${CERTDIR}/${domain}/cert.pem"
+  ln -sf "chain-${timestamp}.pem" "${certdir}/chain.pem"
+  ln -sf "fullchain-${timestamp}.pem" "${certdir}/fullchain.pem"
+  ln -sf "cert-${timestamp}.csr" "${certdir}/cert.csr"
+  ln -sf "cert-${timestamp}.pem" "${certdir}/cert.pem"
 
   # Wait for hook script to clean the challenge and to deploy cert if used
-  [[ -n "${HOOK}" ]] && "${HOOK}" "deploy_cert" "${domain}" "${CERTDIR}/${domain}/privkey.pem" "${CERTDIR}/${domain}/cert.pem" "${CERTDIR}/${domain}/fullchain.pem" "${CERTDIR}/${domain}/chain.pem" "${timestamp}"
+  [[ -n "${HOOK}" ]] && "${HOOK}" "deploy_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem" "${timestamp}"
 
   unset challenge_token
   echo " + Done!"
@@ -798,7 +800,10 @@ command_sign_domains() {
     IFS="${ORIGIFS}"
     domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
     morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
-    cert="${CERTDIR}/${domain}/cert.pem"
+
+    local certdir="${CERTDIR}/${domain}"
+
+    cert="${certdir}/cert.pem"
 
     force_renew="${PARAM_FORCE:-no}"
 
@@ -815,7 +820,7 @@ command_sign_domains() {
     if [[ -n "${DOMAINS_D}" ]]; then
       certconfig="${DOMAINS_D}/${domain}"
     else
-      certconfig="${CERTDIR}/${domain}/config"
+      certconfig="${certdir}/config"
     fi
 
     if [ -f "${certconfig}" ]; then
@@ -879,7 +884,7 @@ command_sign_domains() {
         else
           # Certificate-Names unchanged and cert is still valid
           echo "Skipping renew!"
-          [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${domain}" "${CERTDIR}/${domain}/privkey.pem" "${CERTDIR}/${domain}/cert.pem" "${CERTDIR}/${domain}/fullchain.pem" "${CERTDIR}/${domain}/chain.pem"
+          [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem"
           continue
         fi
       else

--- a/docs/domains_txt.md
+++ b/docs/domains_txt.md
@@ -11,3 +11,22 @@ example.net www.example.net wiki.example.net
 
 This states that there should be two certificates `example.com` and `example.net`,
 with the other domains in the corresponding line being their alternative names.
+
+Per default, the 'primary domain', which is the first name on the line, selects the
+output directory under `CERTDIR` where key and certificate files for each entry are
+written to. The domain-specific configuration file under `DOMAINS_D` or `CERTDIR/domain/config` 
+also uses the primary domain. This works out nicely while all certificates have different
+primary domain names. If multiple certificates should be generated for the same primary
+domain, the respective lines in `domains.txt` can be prefixed with the target alias
+name in the following form:
+
+```text
+--alias example-rsa example.com www.example.com
+--alias example-ecdsa example.com www.example.com
+```
+
+Now the first certificate will look up its configuration settings in `DOMAINS_D/example-rsa`
+or `CERTDIR/example-rsa/config`, and the output will be written to
+`example-rsa` under `CERTDIR`. The second certificate can use different configuration
+settings in the file `example-ecdsa`, and its output is written to the separate
+directory `example-ecdsa` under `CERTDIR`.

--- a/docs/examples/domains.txt
+++ b/docs/examples/domains.txt
@@ -1,2 +1,4 @@
 example.org www.example.org
 example.com www.example.com wiki.example.com
+--alias examplenet-rsa example.net www.example.net
+--alias examplenet-ecdsa example.net www.example.net

--- a/docs/per-certificate-config.md
+++ b/docs/per-certificate-config.md
@@ -3,6 +3,8 @@
 dehydrated allows a few configuration variables to be set on a per-certificate base.
 
 To use this feature create a `config` file in the certificates output directory (e.g. `certs/example.org/config`).
+If DOMAINS_D is set, the respective file name is the name of the certificate,
+inside DOMAINS_D (e.g. `/etc/dehydrated/domains.d/example.org`).
 
 Currently supported options:
 

--- a/test.sh
+++ b/test.sh
@@ -183,6 +183,21 @@ _CHECK_ERRORLOG
 # Disable private key renew
 echo 'PRIVATE_KEY_RENEW="no"' >> config
 
+# Modify domains.txt to contain a leading --alias and an alias for identifying this key/cert
+echo "--alias the_alias ${TMP2_URL} ${TMP3_URL}" > domains.txt
+
+# Run in cron mode but use --alias for choosing the config and output directory
+_TEST "Run in cron mode but use --alias in domains.txt for choosing the config and output directory"
+./dehydrated --cron > tmplog 2> errorlog || _FAIL "Scrip execution failed"
+_CHECK_NOT_LOG "Checking domain name(s) of existing cert"
+_CHECK_LOG "Generating private key"
+_CHECK_LOG "Requesting challenge for ${TMP2_URL}"
+_CHECK_LOG "Requesting challenge for ${TMP3_URL}"
+_CHECK_LOG "Challenge is valid!"
+_CHECK_LOG "Creating fullchain.pem"
+_CHECK_LOG "Done!"
+_CHECK_ERRORLOG
+
 # Run in cron mode one last time, with domain in domains.txt and force-resign (should find certificate, resign anyway, and not generate private key)
 _TEST "Run in cron mode one last time, with domain in domains.txt and force-resign"
 ./dehydrated --cron --force > tmplog 2> errorlog || _FAIL "Script execution failed"


### PR DESCRIPTION
This change adds a feature where each line in domains.txt can be prefixed by "--alias alias-name", where the given alias-name is used instead of the primary (first) domain name on that line, for looking up the configuration and for storing the certificate. With that change it is possible to generate multiple certificates with the same primary domain name and differentiate the configuration and output path via the alias-name. One use case is for generating both an RSA and an ECDSA key/cert combination. This change fixes #396.

[x] tested manually
[x] added simple test case to `test.sh`
[x] added documentation updates