### PR TITLE
configurable OPENSSL variable for each certificate.

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -58,6 +58,7 @@ store_configvars() {
   __HOOK="${HOOK}"
   __WELLKNOWN="${WELLKNOWN}"
   __HOOK_CHAIN="${HOOK_CHAIN}"
+  __OPENSSL="${OPENSSL}"
   __OPENSSL_CNF="${OPENSSL_CNF}"
   __RENEW_DAYS="${RENEW_DAYS}"
   __IP_VERSION="${IP_VERSION}"
@@ -72,6 +73,7 @@ reset_configvars() {
   HOOK="${__HOOK}"
   WELLKNOWN="${__WELLKNOWN}"
   HOOK_CHAIN="${__HOOK_CHAIN}"
+  OPENSSL="${__OPENSSL}"
   OPENSSL_CNF="${__OPENSSL_CNF}"
   RENEW_DAYS="${__RENEW_DAYS}"
   IP_VERSION="${__IP_VERSION}"
@@ -970,7 +972,7 @@ command_sign_domains() {
         config_var="$(echo "${cfgline:1}" | cut -d'=' -f1)"
         config_value="$(echo "${cfgline:1}" | cut -d'=' -f2-)"
         case "${config_var}" in
-          KEY_ALGO|OCSP_MUST_STAPLE|PRIVATE_KEY_RENEW|PRIVATE_KEY_ROLLOVER|KEYSIZE|CHALLENGETYPE|HOOK|WELLKNOWN|HOOK_CHAIN|OPENSSL_CNF|RENEW_DAYS)
+          KEY_ALGO|OCSP_MUST_STAPLE|PRIVATE_KEY_RENEW|PRIVATE_KEY_ROLLOVER|KEYSIZE|CHALLENGETYPE|HOOK|WELLKNOWN|HOOK_CHAIN|OPENSSL|OPENSSL_CNF|RENEW_DAYS)
             echo "   + ${config_var} = ${config_value}"
             declare -- "${config_var}=${config_value}"
             ;;
@@ -981,7 +983,7 @@ command_sign_domains() {
       IFS="${ORIGIFS}"
     fi
     verify_config
-    export WELLKNOWN CHALLENGETYPE KEY_ALGO PRIVATE_KEY_ROLLOVER
+    export WELLKNOWN CHALLENGETYPE KEY_ALGO PRIVATE_KEY_ROLLOVER OPENSSL
 
     skip="no"
 
@@ -1232,7 +1234,7 @@ command_help() {
 command_env() {
   echo "# dehydrated configuration"
   load_config
-  typeset -p CA LICENSE CERTDIR CHALLENGETYPE DOMAINS_D DOMAINS_TXT HOOK HOOK_CHAIN RENEW_DAYS ACCOUNT_KEY ACCOUNT_KEY_JSON KEYSIZE WELLKNOWN PRIVATE_KEY_RENEW OPENSSL_CNF CONTACT_EMAIL LOCKFILE
+  typeset -p CA LICENSE CERTDIR CHALLENGETYPE DOMAINS_D DOMAINS_TXT HOOK HOOK_CHAIN RENEW_DAYS ACCOUNT_KEY ACCOUNT_KEY_JSON KEYSIZE WELLKNOWN PRIVATE_KEY_RENEW OPENSSL OPENSSL_CNF CONTACT_EMAIL LOCKFILE
 }
 
 # Main method (parses script arguments and calls command_* methods)


### PR DESCRIPTION
I want to sign any certificates from custom CSRs generated by appliance equipments, which are HPE iLO4, Infoblox and others.  Almost #377 is same, but not different  approch.

I decided to make OPENSSL variable configurable for each certificate, like `OPENSSL=APPLIANCE_openssl` in ${certdir}/config, not only global.

If **_APPLIANCE_**_openssl called `req -new ...` from dehydrated, it call Generate CSR API to its own appliance equipment like following.

> ilo4_openssl () {
>    if [[ x"${1:-}${2:-}" = x"req-new" ]]; then
>        shift 2
>        while [ "$#" -gt 0 ]; do
>            case "${1}" in
>            -out)
>                ilo4_GenerateCSR $(basename $(dirname ${2})) ${2}
>                ;;
>            *)
>                ;;
>            esac
>            shift
>        done
>    else
>        openssl "${@}"
>    fi
> }

I'm tested on following environment.

-  FreeBSD 11.1-R
- dehydrated v0.4.0 from ports and customed.
- target appliances: HPE iLO4, Infoblox TE-1410(Grid Manager)
