### PR TITLE
#396 alias take 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ This file contains a log of major changes in dehydrated
 - Certificate chain is now cached (CHAINCACHE)
 - OpenSSL binary path is now configurable (OPENSSL)
 - Cleanup now also moves revoked certificates
+- domains.txt and the commandline "--domain" allows one or more alias names to be specified
 
 ## Added
 - New feature for updating contact information (--account)

--- a/dehydrated
+++ b/dehydrated
@@ -974,139 +974,139 @@ command_sign_domains() {
 }
 
 sign_one_domain() {
-    local alias="$1"
-    shift
-    local domain="$1"
-    local altnames="${*}"
-    shift
-    local morenames="${*}"
+  local alias="$1"
+  shift
+  local domain="$1"
+  local altnames="${*}"
+  shift
+  local morenames="${*}"
 
-    local certdir="${CERTDIR}/${alias}"
-    cert="${certdir}/cert.pem"
-    chain="${certdir}/chain.pem"
+  local certdir="${CERTDIR}/${alias}"
+  cert="${certdir}/cert.pem"
+  chain="${certdir}/chain.pem"
 
-    force_renew="${PARAM_FORCE:-no}"
+  force_renew="${PARAM_FORCE:-no}"
 
-    echo -n "Processing ${domain}"
-    [[ -n "${morenames}" ]] && echo -n " with alternative names: ${morenames}"
-    [[ "${alias}" != "${domain}" ]] && echo -n " with alias: ${alias}"
+  echo -n "Processing ${domain}"
+  [[ -n "${morenames}" ]] && echo -n " with alternative names: ${morenames}"
+  [[ "${alias}" != "${domain}" ]] && echo -n " with alias: ${alias}"
 
-    # read cert config
-    # for now this loads the certificate specific config in a subshell and parses a diff of set variables.
-    # we could just source the config file but i decided to go this way to protect people from accidentally overriding
-    # variables used internally by this script itself.
-    if [[ -n "${DOMAINS_D}" ]]; then
-      certconfig="${DOMAINS_D}/${alias}"
+  # read cert config
+  # for now this loads the certificate specific config in a subshell and parses a diff of set variables.
+  # we could just source the config file but i decided to go this way to protect people from accidentally overriding
+  # variables used internally by this script itself.
+  if [[ -n "${DOMAINS_D}" ]]; then
+    certconfig="${DOMAINS_D}/${alias}"
+  else
+    certconfig="${certdir}/config"
+  fi
+
+  if [ -f "${certconfig}" ]; then
+    echo " + Using certificate specific config file!"
+    ORIGIFS="${IFS}"
+    IFS=$'\n'
+    for cfgline in $(
+      beforevars="$(_mktemp)"
+      aftervars="$(_mktemp)"
+      set > "${beforevars}"
+      # shellcheck disable=SC1090
+      . "${certconfig}"
+      set > "${aftervars}"
+      diff -u "${beforevars}" "${aftervars}" | grep -E '^\+[^+]'
+      rm "${beforevars}"
+      rm "${aftervars}"
+    ); do
+      config_var="$(echo "${cfgline:1}" | cut -d'=' -f1)"
+      config_value="$(echo "${cfgline:1}" | cut -d'=' -f2-)"
+      case "${config_var}" in
+        KEY_ALGO|OCSP_MUST_STAPLE|PRIVATE_KEY_RENEW|PRIVATE_KEY_ROLLOVER|KEYSIZE|CHALLENGETYPE|HOOK|WELLKNOWN|HOOK_CHAIN|OPENSSL_CNF|RENEW_DAYS)
+          echo "   + ${config_var} = ${config_value}"
+          declare -- "${config_var}=${config_value}"
+          ;;
+        _) ;;
+        *) echo "   ! Setting ${config_var} on a per-certificate base is not (yet) supported" >&2
+      esac
+    done
+    IFS="${ORIGIFS}"
+  fi
+  verify_config
+  export WELLKNOWN CHALLENGETYPE KEY_ALGO PRIVATE_KEY_ROLLOVER
+
+  skip="no"
+
+  if [[ -e "${cert}" ]]; then
+    printf " + Checking domain name(s) of existing cert..."
+
+    certnames="$("${OPENSSL}" x509 -in "${cert}" -text -noout | grep DNS: | _sed 's/DNS://g' | tr -d ' ' | tr ',' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//')"
+    givennames="$(echo "${altnames}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
+
+    if [[ "${certnames}" = "${givennames}" ]]; then
+      echo " unchanged."
     else
-      certconfig="${certdir}/config"
+      echo " changed!"
+      echo " + Domain name(s) are not matching!"
+      echo " + Names in old certificate: ${certnames}"
+      echo " + Configured names: ${givennames}"
+      echo " + Forcing renew."
+      force_renew="yes"
     fi
+  fi
 
-    if [ -f "${certconfig}" ]; then
-      echo " + Using certificate specific config file!"
-      ORIGIFS="${IFS}"
-      IFS=$'\n'
-      for cfgline in $(
-        beforevars="$(_mktemp)"
-        aftervars="$(_mktemp)"
-        set > "${beforevars}"
-        # shellcheck disable=SC1090
-        . "${certconfig}"
-        set > "${aftervars}"
-        diff -u "${beforevars}" "${aftervars}" | grep -E '^\+[^+]'
-        rm "${beforevars}"
-        rm "${aftervars}"
-      ); do
-        config_var="$(echo "${cfgline:1}" | cut -d'=' -f1)"
-        config_value="$(echo "${cfgline:1}" | cut -d'=' -f2-)"
-        case "${config_var}" in
-          KEY_ALGO|OCSP_MUST_STAPLE|PRIVATE_KEY_RENEW|PRIVATE_KEY_ROLLOVER|KEYSIZE|CHALLENGETYPE|HOOK|WELLKNOWN|HOOK_CHAIN|OPENSSL_CNF|RENEW_DAYS)
-            echo "   + ${config_var} = ${config_value}"
-            declare -- "${config_var}=${config_value}"
-            ;;
-          _) ;;
-          *) echo "   ! Setting ${config_var} on a per-certificate base is not (yet) supported" >&2
-        esac
-      done
-      IFS="${ORIGIFS}"
-    fi
-    verify_config
-    export WELLKNOWN CHALLENGETYPE KEY_ALGO PRIVATE_KEY_ROLLOVER
+  if [[ -e "${cert}" ]]; then
+    echo " + Checking expire date of existing cert..."
+    valid="$("${OPENSSL}" x509 -enddate -noout -in "${cert}" | cut -d= -f2- )"
 
-    skip="no"
-
-    if [[ -e "${cert}" ]]; then
-      printf " + Checking domain name(s) of existing cert..."
-
-      certnames="$("${OPENSSL}" x509 -in "${cert}" -text -noout | grep DNS: | _sed 's/DNS://g' | tr -d ' ' | tr ',' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//')"
-      givennames="$(echo "${altnames}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
-
-      if [[ "${certnames}" = "${givennames}" ]]; then
-        echo " unchanged."
+    printf " + Valid till %s " "${valid}"
+    if "${OPENSSL}" x509 -checkend $((RENEW_DAYS * 86400)) -noout -in "${cert}"; then
+      printf "(Longer than %d days). " "${RENEW_DAYS}"
+      if [[ "${force_renew}" = "yes" ]]; then
+        echo "Ignoring because renew was forced!"
       else
-        echo " changed!"
-        echo " + Domain name(s) are not matching!"
-        echo " + Names in old certificate: ${certnames}"
-        echo " + Configured names: ${givennames}"
-        echo " + Forcing renew."
-        force_renew="yes"
+        # Certificate-Names unchanged and cert is still valid
+        echo "Skipping renew!"
+        [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem"
+        skip="yes"
       fi
+    else
+      echo "(Less than ${RENEW_DAYS} days). Renewing!"
     fi
+  fi
 
-    if [[ -e "${cert}" ]]; then
-      echo " + Checking expire date of existing cert..."
-      valid="$("${OPENSSL}" x509 -enddate -noout -in "${cert}" | cut -d= -f2- )"
+  local update_ocsp
+  update_ocsp="no"
 
-      printf " + Valid till %s " "${valid}"
-      if "${OPENSSL}" x509 -checkend $((RENEW_DAYS * 86400)) -noout -in "${cert}"; then
-        printf "(Longer than %d days). " "${RENEW_DAYS}"
-        if [[ "${force_renew}" = "yes" ]]; then
-          echo "Ignoring because renew was forced!"
-        else
-          # Certificate-Names unchanged and cert is still valid
-          echo "Skipping renew!"
-          [[ -n "${HOOK}" ]] && "${HOOK}" "unchanged_cert" "${domain}" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem"
-          skip="yes"
-        fi
-      else
-        echo "(Less than ${RENEW_DAYS} days). Renewing!"
-      fi
+  # shellcheck disable=SC2086
+  if [[ ! "${skip}" = "yes" ]]; then
+    update_ocsp="yes"
+    if [[ "${PARAM_KEEP_GOING:-}" = "yes" ]]; then
+      sign_domain "${certdir}" ${altnames} &
+      wait $! || true
+    else
+      sign_domain "${certdir}" ${altnames}
     fi
+  fi
 
-    local update_ocsp
-    update_ocsp="no"
+  if [[ "${OCSP_FETCH}" = "yes" ]]; then
+    local ocsp_url
+    ocsp_url="$(get_ocsp_url "${cert}")"
 
-    # shellcheck disable=SC2086
-    if [[ ! "${skip}" = "yes" ]]; then
+    if [[ ! -e "${certdir}/ocsp.der" ]]; then
       update_ocsp="yes"
-      if [[ "${PARAM_KEEP_GOING:-}" = "yes" ]]; then
-        sign_domain "${certdir}" ${altnames} &
-        wait $! || true
+    elif ! ("${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respin "${certdir}/ocsp.der" -status_age 432000 2>&1 | grep -q "${cert}: good"); then
+      update_ocsp="yes"
+    fi
+
+    if [[ "${update_ocsp}" = "yes" ]]; then
+      echo " + Updating OCSP stapling file"
+      ocsp_timestamp="$(date +%s)"
+      if grep -qE "^(0|(1\.0))\." <<< "$(${OPENSSL} version | awk '{print $2}')"; then
+        "${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respout "${certdir}/ocsp-${ocsp_timestamp}.der" -url "${ocsp_url}" -header "HOST" "$(echo "${ocsp_url}" | _sed -e 's/^http(s?):\/\///' -e 's/\/.*$//g')" > /dev/null 2>&1
       else
-        sign_domain "${certdir}" ${altnames}
+        "${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respout "${certdir}/ocsp-${ocsp_timestamp}.der" -url "${ocsp_url}" > /dev/null 2>&1
       fi
+      ln -sf "${certdir}/ocsp-${ocsp_timestamp}.der" "${certdir}/ocsp.der"
     fi
-
-    if [[ "${OCSP_FETCH}" = "yes" ]]; then
-      local ocsp_url
-      ocsp_url="$(get_ocsp_url "${cert}")"
-
-      if [[ ! -e "${certdir}/ocsp.der" ]]; then
-        update_ocsp="yes"
-      elif ! ("${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respin "${certdir}/ocsp.der" -status_age 432000 2>&1 | grep -q "${cert}: good"); then
-        update_ocsp="yes"
-      fi
-
-      if [[ "${update_ocsp}" = "yes" ]]; then
-        echo " + Updating OCSP stapling file"
-        ocsp_timestamp="$(date +%s)"
-        if grep -qE "^(0|(1\.0))\." <<< "$(${OPENSSL} version | awk '{print $2}')"; then
-          "${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respout "${certdir}/ocsp-${ocsp_timestamp}.der" -url "${ocsp_url}" -header "HOST" "$(echo "${ocsp_url}" | _sed -e 's/^http(s?):\/\///' -e 's/\/.*$//g')" > /dev/null 2>&1
-        else
-          "${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respout "${certdir}/ocsp-${ocsp_timestamp}.der" -url "${ocsp_url}" > /dev/null 2>&1
-        fi
-        ln -sf "${certdir}/ocsp-${ocsp_timestamp}.der" "${certdir}/ocsp.der"
-      fi
-    fi
+  fi
 }
 
 # Usage: --signcsr (-s) path/to/csr.pem

--- a/dehydrated
+++ b/dehydrated
@@ -933,31 +933,70 @@ command_sign_domains() {
   # Generate certificates for all domains found in domains.txt. Check if existing certificate are about to expire
   ORIGIFS="${IFS}"
   IFS=$'\n'
-  for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' | (grep -vE '^(#|$)' || true)); do
+  for line in $(<"${DOMAINS_TXT}" tr -d '\r' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/[[:space:]]*>[[:space:]]*/>/g' -e 's/(.)>/\1 >/g' | (grep -vE '^(#|$)' || true)); do
     reset_configvars
     IFS="${ORIGIFS}"
-    local domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
-    local morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
-    local altnames="${primary} ${morenames}"
-    altnames="${altnames%% }"
-    local certdir="${CERTDIR}/${domain}"
+    local aliases=""
+    local domain=""
+    local morenames=""
+    for elem in ${line}; do
+      case "${elem}" in
+      \>*) aliases+=" ${elem#>}"
+           ;;
+      *)   local domlower="$(<<< "${elem}" awk '{print tolower($0)}')"
+           if [[ -z "${domain}" ]]; then
+             domain="${domlower}"
+           else
+             morenames+=" ${domlower}"
+           fi
+           ;;
+      esac
+    done
+    aliases="${aliases# }"
+    morenames="${morenames# }"
+    [[ -z "${aliases}" ]] &&  aliases="${domain}"
+
+    for alias in ${aliases}; do
+      echo "${alias}" "${domain}" ${morenames}
+      sign_one_domain "${alias}" "${domain}" ${morenames}
+    done
+  done
+
+  # remove temporary domains.txt file if used
+  [[ -n "${PARAM_DOMAIN:-}" ]] && rm -f "${DOMAINS_TXT}"
+
+  [[ -n "${HOOK}" ]] && "${HOOK}" "exit_hook"
+  if [[ "${AUTO_CLEANUP}" == "yes" ]]; then
+    echo "+ Running automatic cleanup"
+    command_cleanup noinit
+  fi
+  exit 0
+}
+
+sign_one_domain() {
+    local alias="$1"
+    shift
+    local domain="$1"
+    local altnames="${*}"
+    shift
+    local morenames="${*}"
+
+    local certdir="${CERTDIR}/${alias}"
     cert="${certdir}/cert.pem"
     chain="${certdir}/chain.pem"
 
     force_renew="${PARAM_FORCE:-no}"
 
-    if [[ -z "${morenames}" ]];then
-      echo "Processing ${domain}"
-    else
-      echo "Processing ${domain} with alternative names: ${morenames}"
-    fi
+    echo -n "Processing ${domain}"
+    [[ -n "${morenames}" ]] && echo -n " with alternative names: ${morenames}"
+    [[ "${alias}" != "${domain}" ]] && echo -n " with alias: ${alias}"
 
     # read cert config
     # for now this loads the certificate specific config in a subshell and parses a diff of set variables.
     # we could just source the config file but i decided to go this way to protect people from accidentally overriding
     # variables used internally by this script itself.
     if [[ -n "${DOMAINS_D}" ]]; then
-      certconfig="${DOMAINS_D}/${domain}"
+      certconfig="${DOMAINS_D}/${alias}"
     else
       certconfig="${certdir}/config"
     fi
@@ -1068,17 +1107,6 @@ command_sign_domains() {
         ln -sf "${certdir}/ocsp-${ocsp_timestamp}.der" "${certdir}/ocsp.der"
       fi
     fi
-  done
-
-  # remove temporary domains.txt file if used
-  [[ -n "${PARAM_DOMAIN:-}" ]] && rm -f "${DOMAINS_TXT}"
-
-  [[ -n "${HOOK}" ]] && "${HOOK}" "exit_hook"
-  if [[ "${AUTO_CLEANUP}" == "yes" ]]; then
-    echo "+ Running automatic cleanup"
-    command_cleanup noinit
-  fi
-  exit 0
 }
 
 # Usage: --signcsr (-s) path/to/csr.pem

--- a/dehydrated
+++ b/dehydrated
@@ -717,8 +717,10 @@ walk_chain() {
 
 # Create certificate for domain(s)
 sign_domain() {
-  domain="${1}"
-  altnames="${*}"
+  local certdir="${1}"
+  shift
+  local domain="${1}"
+  local altnames="${*}"
   timestamp="$(date +%s)"
 
   export altnames
@@ -727,8 +729,6 @@ sign_domain() {
   if [[ -z "${CA_NEW_AUTHZ}" ]] || [[ -z "${CA_NEW_CERT}" ]]; then
     _exiterr "Certificate authority doesn't allow certificate signing"
   fi
-
-  local certdir="${CERTDIR}/${domain}"
 
   # If there is no existing certificate directory => make it
   if [[ ! -e "${certdir}" ]]; then
@@ -936,8 +936,10 @@ command_sign_domains() {
   for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' | (grep -vE '^(#|$)' || true)); do
     reset_configvars
     IFS="${ORIGIFS}"
-    domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
-    morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
+    local domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
+    local morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
+    local altnames="${primary} ${morenames}"
+    altnames="${altnames%% }"
     local certdir="${CERTDIR}/${domain}"
     cert="${certdir}/cert.pem"
     chain="${certdir}/chain.pem"
@@ -997,7 +999,7 @@ command_sign_domains() {
       printf " + Checking domain name(s) of existing cert..."
 
       certnames="$("${OPENSSL}" x509 -in "${cert}" -text -noout | grep DNS: | _sed 's/DNS://g' | tr -d ' ' | tr ',' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//')"
-      givennames="$(echo "${domain}" "${morenames}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
+      givennames="$(echo "${altnames}"| tr ' ' '\n' | sort -u | tr '\n' ' ' | _sed 's/ $//' | _sed 's/^ //')"
 
       if [[ "${certnames}" = "${givennames}" ]]; then
         echo " unchanged."
@@ -1038,10 +1040,10 @@ command_sign_domains() {
     if [[ ! "${skip}" = "yes" ]]; then
       update_ocsp="yes"
       if [[ "${PARAM_KEEP_GOING:-}" = "yes" ]]; then
-        sign_domain ${line} &
+        sign_domain "${certdir}" ${altnames} &
         wait $! || true
       else
-        sign_domain ${line}
+        sign_domain "${certdir}" ${altnames}
       fi
     fi
 

--- a/docs/domains_txt.md
+++ b/docs/domains_txt.md
@@ -11,3 +11,32 @@ example.net www.example.net wiki.example.net
 
 This states that there should be two certificates `example.com` and `example.net`,
 with the other domains in the corresponding line being their alternative names.
+
+Per default, the 'primary domain', which is the first name on the line, selects the
+output directory under `CERTDIR` where key and certificate files for each entry are
+written to. The domain-specific configuration file under `DOMAINS_D` or `CERTDIR/domain/config` 
+also uses the primary domain. This works out nicely while all certificates have different
+primary domain names, and the storage directory should be based on that primary domain name.
+If this turns out to be a limitation, e.g. because multiple certificates should be
+generated for the same primary domain, the respective lines in `domains.txt` can be tagged
+wit an alias name, such that this alias name is used for additional configuration lookup
+under `DOMAINS_D` as well as the key/certificate storage directory under `CERTDIR`. Use
+the following form in `domains.txt` to specify the alias name:
+
+```text
+>example-rsa example.com www.example.com
+>example-ecdsa example.com www.example.com
+```
+
+Now the first certificate will look up its configuration settings in `DOMAINS_D/example-rsa`
+or `CERTDIR/example-rsa/config`, and the output will be written to
+`example-rsa` under `CERTDIR`. The second certificate can use different configuration
+settings in the file `example-ecdsa`, and its output is written to the separate
+directory `example-ecdsa` under `CERTDIR`. If two certificates should be generated with the
+exact same set of domains, the two aliases can be placed on a single line. The given
+example could be reduced to the following configuration in `domains.txt`. Note that the
+alias can be stated anywhere on the line.
+
+```text
+example.com www.example.com >example-rsa >example-ecdsa
+```

--- a/docs/examples/domains.txt
+++ b/docs/examples/domains.txt
@@ -1,2 +1,3 @@
 example.org www.example.org
 example.com www.example.com wiki.example.com
+>examplenet-rsa >examplenet-ecdsa example.net www.example.net

--- a/docs/per-certificate-config.md
+++ b/docs/per-certificate-config.md
@@ -4,6 +4,11 @@ dehydrated allows a few configuration variables to be set on a per-certificate b
 
 To use this feature create a `config` file in the certificates output directory (e.g. `certs/example.org/config`).
 
+If `DOMAINS_D` is set, the respective file name is the name of the certificate, inside `DOMAINS_D`
+(e.g. if `DOMAINS_D=/etc/dehydrated/domains.d`, then a certificate for the domain `example.org` will
+use additional configuration parameters from `/etc/dehydrated/domains.d/example.org`). If the certificate
+is generated from an alias name, then this name forms the file name.
+
 Currently supported options:
 
 - PRIVATE_KEY_RENEW

--- a/test.sh
+++ b/test.sh
@@ -183,6 +183,22 @@ _CHECK_ERRORLOG
 # Disable private key renew
 echo 'PRIVATE_KEY_RENEW="no"' >> config
 
+# Modify domains.txt to contain a leading >alias for identifying this key/cert
+echo ">the_alias ${TMP2_URL} ${TMP3_URL}" > domains.txt
+
+# Run in cron mode but use >alias notation for choosing the config and output directory
+_TEST "Run in cron mode but use >alias notation in domains.txt for choosing the config and output directory"
+./dehydrated --cron > tmplog 2> errorlog || _FAIL "Scrip execution failed"
+_CHECK_NOT_LOG "Checking domain name(s) of existing cert"
+_CHECK_LOG "Generating private key"
+_CHECK_LOG "Requesting challenge for ${TMP2_URL}"
+_CHECK_LOG "Requesting challenge for ${TMP3_URL}"
+_CHECK_LOG "Challenge is valid!"
+_CHECK_LOG "Creating fullchain.pem"
+_CHECK_LOG "Done!"
+_CHECK_ERRORLOG
+
+
 # Run in cron mode one last time, with domain in domains.txt and force-resign (should find certificate, resign anyway, and not generate private key)
 _TEST "Run in cron mode one last time, with domain in domains.txt and force-resign"
 ./dehydrated --cron --force > tmplog 2> errorlog || _FAIL "Script execution failed"


### PR DESCRIPTION
This is the second attempt to adding the alias feature. Thanks to Dirk’s input, the feature has now a more concise configuration syntax and allows specifying of multiple aliases, i.e. multiple similar certificates for the same set of domains on one line in `domains.txt`.

- [x] implemented
- [x] added docs
- [ ] extensively tested
