### PR TITLE
fix --account command backup file path generation

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -903,7 +903,7 @@ command_account() {
     echo "+ Account information was the same after the update"
     rm "${NEW_ACCOUNT_KEY_JSON}"
   else
-    ACCOUNT_KEY_JSON_BACKUP="$(echo "${ACCOUNT_KEY_JSON}" | cut -d. -f1)-$(date +%s).json"
+    ACCOUNT_KEY_JSON_BACKUP="${ACCOUNT_KEY_JSON%.*}-$(date +%s).json"
     echo "+ Backup ${ACCOUNT_KEY_JSON} as ${ACCOUNT_KEY_JSON_BACKUP}"
     cp -p "${ACCOUNT_KEY_JSON}" "${ACCOUNT_KEY_JSON_BACKUP}"
     echo "+ Populate ${ACCOUNT_KEY_JSON}"


### PR DESCRIPTION
it should split the filename on the last dot instead of the first

example of problem if you have a dot in your path (e.g. the dot in my username **a.loibl**):
```
$ dehydrated --account
# INFO: Using main config file /home/a.loibl/xxx/config
+ Updating registration id: 11447865 contact information...
+ Backup /home/a.loibl/xxx/accounts/xxx/registration_info.json as /home/a-1508250049.json
cp: cannot create regular file ‘/home/a-1508250049.json’: Permission denied
```

with this change:
```
$ dehydrated --account
# INFO: Using main config file /home/a.loibl/xxx/config
+ Updating registration id: 11447865 contact information...
+ Backup /home/a.loibl/xxx/accounts/xxx/registration_info.json as /home/a.loibl/xxx/accounts/xxx/registration_info-1508250417.json
+ Populate /home/a.loibl/xxx/accounts/xxx/registration_info.json
+ Done!
```