### PR TITLE
be more verbose on OCSP stapling file updates

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1046,6 +1046,7 @@ command_sign_domains() {
     fi
 
     if [[ "${OCSP_FETCH}" = "yes" ]]; then
+      echo " + Checking update of OCSP stapling file for ${domain}"
       local ocsp_url
       ocsp_url="$(get_ocsp_url "${cert}")"
 
@@ -1056,7 +1057,7 @@ command_sign_domains() {
       fi
 
       if [[ "${update_ocsp}" = "yes" ]]; then
-        echo " + Updating OCSP stapling file"
+        echo " + Updating OCSP stapling file for ${domain}"
         ocsp_timestamp="$(date +%s)"
         if grep -qE "^(0|(1\.0))\." <<< "$(${OPENSSL} version | awk '{print $2}')"; then
           "${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respout "${certdir}/ocsp-${ocsp_timestamp}.der" -url "${ocsp_url}" -header "HOST" "$(echo "${ocsp_url}" | _sed -e 's/^http(s?):\/\///' -e 's/\/.*$//g')" > /dev/null 2>&1
@@ -1064,6 +1065,8 @@ command_sign_domains() {
           "${OPENSSL}" ocsp -no_nonce -issuer "${chain}" -verify_other "${chain}" -cert "${cert}" -respout "${certdir}/ocsp-${ocsp_timestamp}.der" -url "${ocsp_url}" > /dev/null 2>&1
         fi
         ln -sf "ocsp-${ocsp_timestamp}.der" "${certdir}/ocsp.der"
+      else
+        echo " + Skipping update of OCSP stapling file for ${domain}"
       fi
     fi
   done


### PR DESCRIPTION
related to issue #385 
The OCSP update basically works like a charm, but it was making me pretty nervous to not see anything in the output related to OCSP when configuring it.
This is because the only echo was executed after the age check said an update is needed, so I propose to change that.