### PR TITLE
--domain param accepts filename to change domains.txt

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -229,6 +229,7 @@ load_config() {
   [[ -n "${PARAM_NO_LOCK:-}" ]] && LOCKFILE=""
 
   [[ -n "${PARAM_HOOK:-}" ]] && HOOK="${PARAM_HOOK}"
+  [[ -n "${PARAM_DOMAINS_TXT:-}" ]] && DOMAINS_TXT="${PARAM_DOMAINS_TXT}"
   [[ -n "${PARAM_CERTDIR:-}" ]] && CERTDIR="${PARAM_CERTDIR}"
   [[ -n "${PARAM_CHALLENGETYPE:-}" ]] && CHALLENGETYPE="${PARAM_CHALLENGETYPE}"
   [[ -n "${PARAM_KEY_ALGO:-}" ]] && KEY_ALGO="${PARAM_KEY_ALGO}"
@@ -1379,7 +1380,9 @@ main() {
       --domain|-d)
         shift 1
         check_parameters "${1:-}"
-        if [[ -z "${PARAM_DOMAIN:-}" ]]; then
+        if [[ -f "${1}" ]]; then
+          PARAM_DOMAINS_TXT="${1}"
+        elif [[ -z "${PARAM_DOMAIN:-}" ]]; then
           PARAM_DOMAIN="${1}"
         else
           PARAM_DOMAIN="${PARAM_DOMAIN} ${1}"


### PR DESCRIPTION
As stated in #462, I have several `domains.txt`s. This change makes different configs with different `DOMAINS_TXT`s unnecessary.