### PR TITLE
Fix grammer error in the manpage

### DIFF
--- a/dehydrated.1
+++ b/dehydrated.1
@@ -7,8 +7,8 @@ dehydrated \- ACME client implemented as a shell-script
 [\fBargument\fR [\fBargument\fR]]
 .IR ...
 .SH DESCRIPTION
-A client for ACME-based Certificate Authorities, such as LetsEncrypt.  It
-allows to request and obtain TLS certificates from an ACME-based
+A client for ACME-based Certificate Authorities, such as LetsEncrypt.  It can
+be used to request and obtain TLS certificates from an ACME-based
 certificate authority.
 
 Before any certificates can be requested, Dehydrated needs


### PR DESCRIPTION
"allows to" requires a subject (e.g. "allows one to"), without it's just
syntactically wrong.  Change the verb entirely to workaround the
problem.