### PR TITLE
openssl: do not use -out when generating private keys

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -309,7 +309,7 @@ init_system() {
       fi
 
       echo "+ Generating account key..."
-      _openssl genrsa -out "${ACCOUNT_KEY}" "${KEYSIZE}"
+      _openssl_stdout genrsa "${KEYSIZE}" > "${ACCOUNT_KEY}"
       register_new_key="yes"
     fi
   fi
@@ -426,6 +426,22 @@ rm_json_arrays() {
 _openssl() {
   set +e
   out="$("${OPENSSL}" "${@}" 2>&1)"
+  res=$?
+  set -e
+  if [[ ${res} -ne 0 ]]; then
+    echo "  + ERROR: failed to run $* (Exitcode: ${res})" >&2
+    echo >&2
+    echo "Details:" >&2
+    echo "${out}" >&2
+    echo >&2
+    exit ${res}
+  fi
+}
+
+# Same, but when we need OpenSSL's stdout intact
+_openssl_stdout() {
+  set +e
+  { out="$("${OPENSSL}" "${@}" 2>&1 1>&3-)"; } 3>&1
   res=$?
   set -e
   if [[ ${res} -ne 0 ]]; then
@@ -875,8 +891,8 @@ sign_domain() {
     echo " + Generating private key..."
     privkey="privkey-${timestamp}.pem"
     case "${KEY_ALGO}" in
-      rsa) _openssl genrsa -out "${certdir}/privkey-${timestamp}.pem" "${KEYSIZE}";;
-      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${certdir}/privkey-${timestamp}.pem";;
+      rsa) _openssl_stdout genrsa "${KEYSIZE}" > "${certdir}/privkey-${timestamp}.pem";;
+      prime256v1|secp384r1) _openssl_stdout ecparam -genkey -name "${KEY_ALGO}" > "${certdir}/privkey-${timestamp}.pem";;
     esac
   fi
   # move rolloverkey into position (if any)
@@ -890,8 +906,8 @@ sign_domain() {
   if [[ ! -r "${certdir}/privkey.roll.pem" && "${PRIVATE_KEY_ROLLOVER}" = "yes" && "${PRIVATE_KEY_RENEW}" = "yes" ]]; then
     echo " + Generating private rollover key..."
     case "${KEY_ALGO}" in
-      rsa) _openssl genrsa -out "${certdir}/privkey.roll.pem" "${KEYSIZE}";;
-      prime256v1|secp384r1) _openssl ecparam -genkey -name "${KEY_ALGO}" -out "${certdir}/privkey.roll.pem";;
+      rsa) _openssl_stdout genrsa "${KEYSIZE}" > "${certdir}/privkey.roll.pem";;
+      prime256v1|secp384r1) _openssl_stdout ecparam -genkey -name "${KEY_ALGO}" > "${certdir}/privkey.roll.pem";;
     esac
   fi
   # delete rolloverkeys if disabled


### PR DESCRIPTION
`openssl genrsa` and `openssl ecparam -genkey` tend to chmod the output
file to make the private key unreadable by group and others. This breaks
a workflow where admin uses POSIX ACLs to manage keys' access rights,
because POSIX ACLs reuse group permissions for the "ACL mask", hence
forcing group permissions to 0 with plain chmod() masks away all
extended ACLs.

By redirecting genrsa output from stdout we avoid this behavior while
staying secure even if ACLs are not used because we explicitly set
`umask 077` in the beginning of the script.

Example of the broken behavior:
```
# pwd                 
/etc/admin/certs/intelfx.name

# getfacl .
# file: .
# owner: letsencrypt
# group: letsencrypt
user::rwx
group::---
group:http-cert:r-x
mask::r-x
other::---
default:user::rwx
default:group::---
default:group:http-cert:r-x
default:mask::r-x
default:other::---

# getfacl cert.pem
# file: cert.pem
# owner: letsencrypt
# group: letsencrypt
user::rw-
group::---
group:http-cert:r--
mask::r--
other::---

# getfacl privkey.pem           
# file: privkey.pem
# owner: letsencrypt
# group: letsencrypt
user::rw-
group::---
group:http-cert:r--             #effective:---
mask::---
other::---
```

Here I run dehydrated as `letsencrypt:letsencrypt` and use group `http-cert` for all applications that need access to the certificates and the private key. The output directory is modified as follows:
```
setfacl -m u::rwX,g::0,o::0 -m g:http-cert:rX .
setfacl -d -m u::rwX,g::0,o::0 -m g:http-cert:rX .
```