### PR TITLE
Add ^~ to nginx location block

### DIFF
--- a/docs/wellknown.md
+++ b/docs/wellknown.md
@@ -24,7 +24,7 @@ With Nginx you'll need to add this to any of your `server`/VHost config blocks:
 ```nginx
 server {
   [...]
-  location /.well-known/acme-challenge {
+  location ^~ /.well-known/acme-challenge {
     alias /var/www/dehydrated;
   }
   [...]


### PR DESCRIPTION
To make sure it is not overridden.
> http://nginx.org/en/docs/http/ngx_http_core_module.html#location :
> If the longest matching prefix location has the “^~” modifier then regular expressions are not checked.