### PR TITLE
Fix globbing of CONFIG_D *.sh files

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -158,6 +158,9 @@ load_config() {
       _exiterr "The path ${CONFIG_D} specified for CONFIG_D does not point to a directory."
     fi
 
+    # Allow globbing
+    [[ -n "${ZSH_VERSION:-}" ]] && set +o noglob || set +f
+
     for check_config_d in "${CONFIG_D}"/*.sh; do
       if [[ -f "${check_config_d}" ]] && [[ -r "${check_config_d}" ]]; then
         echo "# INFO: Using additional config file ${check_config_d}"
@@ -166,7 +169,10 @@ load_config() {
       else
         _exiterr "Specified additional config ${check_config_d} is not readable or not a file at all."
       fi
-   done
+    done
+
+    # Disable globbing
+    [[ -n "${ZSH_VERSION:-}" ]] && set -o noglob || set -f
   fi
 
   # Check if we are running & are allowed to run as root


### PR DESCRIPTION
With the globbing changes made in 61083cf52231e09e3a9b599d602c06978704ec57 to globally disable globbing by default, this broke the ability to load the CONFIG_D `*.sh` files.

This re-enables globbing when reading these `*.sh` files and then disables it again afterwards. Note that this also keeps globbing enabled inside the loop, when sourcing the individual `*.sh` files for backwards compatibility (so if the individual config scripts relied on the default of globbing being enabled, there won't be any change in behavior).