### PR TITLE
fixed "sed: invalid option -- 'E'"

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -713,7 +713,7 @@ sign_csr() {
     fi
 
     # Check if authorization has already been validated
-    if [ "$(echo "${response}" | sed -E 's/"challenges": \[\{.*\}\]//' | get_json_string_value status)" = "valid" ] && [ ! "${PARAM_FORCE:-no}" = "yes" ]; then
+    if [ "$(echo "${response}" | _sed 's/"challenges": \[\{.*\}\]//' | get_json_string_value status)" = "valid" ] && [ ! "${PARAM_FORCE:-no}" = "yes" ]; then
       echo " + Found valid authorization for ${identifier}"
       continue
     fi


### PR DESCRIPTION
While hitting a Let's Encrypt rate limit dehydrated printed this error:

``sed: invalid option -- 'E'``

This is caused by one occurrence in dehydrated where sed is used directly instead of the _sed wrapper. This pull requests fixes this.