### PR TITLE
deploy_ocsp timestamp parameter in example hook file is wrong

### DIFF
--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -65,7 +65,7 @@ deploy_cert() {
 }
 
 deploy_ocsp() {
-    local DOMAIN="${1}" OCSPFILE="${2}" TIMESTAMP="${6}"
+    local DOMAIN="${1}" OCSPFILE="${2}" TIMESTAMP="${3}"
 
     # This hook is called once for each updated ocsp stapling file that has
     # been produced. Here you might, for instance, copy your new ocsp stapling


### PR DESCRIPTION
probably copy-paste from further up, timestamp is parameter 3