### PR TITLE
New hook to be called before challenge validation

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -777,6 +777,9 @@ sign_csr() {
     fi
   fi
 
+  # Call hook before challenge validation
+  [[ -n "${HOOK}" ]] && "${HOOK}" "before_challenge_validation"
+
   # Validate pending challenges
   local idx=0
   while [ ${idx} -lt ${num_pending_challenges} ]; do


### PR DESCRIPTION
After adding/removing resource records on ClouDNS (and probably other authoritative DNS providers, I guess) you have to wait while the new zone is propagated across all of their servers. This is a time-consuming process and it isn't really predictable, luckily ClouDNS offers a way to check if the zone [is updated](https://www.cloudns.net/wiki/article/54/).

Now that `deploy_challenge` is done for all `-d domain`s at once it would be great to have a hook that is called after all `deploy_challenge`s but before these challenges are validated. That way we can make `deploy_challenge` add all TXT records asynchronously and call just one loop in `before_challenge_validation` to wait while the zone isn't updated across all ClouDNS servers.