### PR TITLE
Adds keep_going parameter to example config file

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -117,3 +117,6 @@
 
 # ACME API version (default: auto)
 #API=auto
+
+# Keep going after encountering an error while creating/renewing multiple certificates in cron mode
+#PARAM_KEEP_GOING="yes"


### PR DESCRIPTION
It would be nice, if the keep_going parameter were listed in the example config file, otherwise it is pretty difficult to find.