### PR TITLE
Ensure files are written to disk before symlink

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1049,6 +1049,9 @@ sign_domain() {
     rm "${tmpcert}" "${tmpchain}"
   fi
 
+  # Wait for hook script to sync the files before creating the symlinks
+  [[ -n "${HOOK}" ]] && "${HOOK}" "sync_cert" "${certdir}/privkey.pem" "${certdir}/cert.pem" "${certdir}/fullchain.pem" "${certdir}/chain.pem" "${certdir}/cert.csr"
+
   # Update symlinks
   [[ "${privkey}" = "privkey.pem" ]] || ln -sf "privkey-${timestamp}.pem" "${certdir}/privkey.pem"
 

--- a/docs/examples/hook.sh
+++ b/docs/examples/hook.sh
@@ -37,6 +37,29 @@ clean_challenge() {
     # printf 'server 127.0.0.1\nupdate delete _acme-challenge.%s TXT "%s"\nsend\n' "${DOMAIN}" "${TOKEN_VALUE}" | nsupdate -k /var/run/named/session.key
 }
 
+sync_cert() {
+    local KEYFILE="${1}" CERTFILE="${2}" FULLCHAINFILE="${3}" CHAINFILE="${4}" REQUESTFILE="${5}"
+
+    # This hook is called after the certificates have been created but before
+    # they are symlinked. This allows you to sync the files to disk to prevent
+    # creating a symlink to empty files.
+    #
+    # Parameters:
+    # - KEYFILE
+    #   The path of the file containing the private key.
+    # - CERTFILE
+    #   The path of the file containing the signed certificate.
+    # - FULLCHAINFILE
+    #   The path of the file containing the full certificate chain.
+    # - CHAINFILE
+    #   The path of the file containing the intermediate certificate(s).
+    # - REQUESTFILE
+    #   The path of the file containing the certificate signing request.
+
+    # Simple example: sync the files before symlinking them
+    # sync "${KEYFILE}" "${CERTFILE} "${FULLCHAINFILE}" "${CHAINFILE}" "${REQUESTFILE}"
+}
+
 deploy_cert() {
     local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
 
@@ -185,6 +208,6 @@ exit_hook() {
 }
 
 HANDLER="$1"; shift
-if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|deploy_cert|deploy_ocsp|unchanged_cert|invalid_challenge|request_failure|generate_csr|startup_hook|exit_hook)$ ]]; then
+if [[ "${HANDLER}" =~ ^(deploy_challenge|clean_challenge|sync_cert|deploy_cert|deploy_ocsp|unchanged_cert|invalid_challenge|request_failure|generate_csr|startup_hook|exit_hook)$ ]]; then
   "$HANDLER" "$@"
 fi


### PR DESCRIPTION
We encountered an issue on a device using UBIFS where if a power cycle
happens close enough after invoking dehydrated only the metadata would
have been written and the symlink points to an empty file e.g.

-rw------- 1 root root  0 Nov 30 13:20 chain-1543580304.pem
lrwxrwxrwx 1 root root 20 Nov 30 13:20 chain.pem -> chain-1543580304.pem
-rw------- 1 root root  0 Nov 30 13:20 fullchain-1543580304.pem
lrwxrwxrwx 1 root root 24 Nov 30 13:20 fullchain.pem -> fullchain-1543580304.pem

Forcing a sync of the symlinked files prevents this from occurring.

Signed-off-by: Frank Vanbever <frank.vanbever@essensium.com>