### PR TITLE
Add sleep timer for dns-01 challenges

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ This file contains a log of major changes in dehydrated
 
 ## Added
 - Initial support for tls-alpn-01 validation
+- Optional sleep timer when using dns-01 to allow DNS to propagate
 
 ## [0.6.2] - 2018-04-25
 ## Added

--- a/dehydrated
+++ b/dehydrated
@@ -784,6 +784,9 @@ sign_csr() {
         idx=$((idx+1))
       done
     fi
+
+    # Sleep if dns-01 and sleep time defined
+    [[ "${CHALLENGETYPE}" == "dns-01" ]] && [[ -n "${SLEEPTIME}" ]] && [[ ${SLEEPTIME} -gt 0 ]] && echo " + Sleeping for ${SLEEPTIME} seconds..." && sleep ${SLEEPTIME}
   fi
 
   # Validate pending challenges

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -34,6 +34,10 @@
 # Which challenge should be used? Currently http-01, dns-01 and tls-alpn-01 are supported
 #CHALLENGETYPE="http-01"
 
+# How long to sleep before validating challenges
+# Only used if CHALLENGETYPE="dns-01"
+#SLEEPTIME=300
+
 # Path to a directory containing additional config files, allowing to override
 # the defaults found in the main configuration file. Additional config files
 # in this directory needs to be named with a '.sh' ending.


### PR DESCRIPTION
This adds an optional sleep timer when there are pending challenges and the challenge type is dns-01.  It allows time for DNS to propagate for some slower providers if needed.

To use it, enable `SLEEPTIME=X` in your config, where `X` is a positive integer value in seconds.  This will pause the script just after deploying the challenges (only if there were challenges) before continuing to the validation phase.  This works especially well when coupled with [lexicon](https://github.com/AnalogJ/lexicon) in a hook script.