### PR TITLE
export HOOK_CHAIN when calling HOOK

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -324,7 +324,7 @@ init_system() {
   fi
 
   # Export some environment variables to be used in hook script
-  export WELLKNOWN BASEDIR CERTDIR ALPNCERTDIR CONFIG COMMAND
+  export WELLKNOWN BASEDIR CERTDIR ALPNCERTDIR CONFIG COMMAND HOOK_CHAIN
 
   # Checking for private key ...
   register_new_key="no"
@@ -1264,7 +1264,7 @@ command_sign_domains() {
     fi
     verify_config
     hookscript_bricker_hook
-    export WELLKNOWN CHALLENGETYPE KEY_ALGO PRIVATE_KEY_ROLLOVER
+    export WELLKNOWN CHALLENGETYPE KEY_ALGO PRIVATE_KEY_ROLLOVER HOOK_CHAIN
 
     skip="no"
 


### PR DESCRIPTION
A generic hook needs to know if HOOK_CHAIN is set to yes in order to
handle parameters/arguments accordingly.