### PR TITLE
support running on MirBSD

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1043,7 +1043,7 @@ command_version() {
   revision="$(cd "${SCRIPTDIR}"; git rev-parse HEAD 2>/dev/null || echo "unknown")"
   echo "GIT-Revision: ${revision}"
   echo ""
-  if [[ "${OSTYPE}" = "FreeBSD" ]]; then
+  if [[ "${OSTYPE}" = "FreeBSD" || $OSTYPE = MirBSD ]]; then
     echo "OS: $(uname -sr)"
   else
     echo "OS: $(cat /etc/issue | grep -v ^$ | head -n1 | _sed 's/\\(r|n|l) .*//g')"
@@ -1052,15 +1052,19 @@ command_version() {
   [[ -n "${BASH_VERSION:-}" ]] && echo " bash: ${BASH_VERSION}"
   [[ -n "${ZSH_VERSION:-}" ]] && echo " zsh: ${ZSH_VERSION}"
   echo " curl: $(curl --version 2>&1 | head -n1 | cut -d" " -f1-2)"
-  if [[ "${OSTYPE}" = "FreeBSD" ]]; then
-    echo " awk, sed, mktemp: FreeBSD base system versions"
+  if [[ "${OSTYPE}" = "FreeBSD" || $OSTYPE = MirBSD ]]; then
+    echo " awk, sed, mktemp: BSD base system versions"
   else
     echo " awk: $(awk -W version 2>&1 | head -n1)"
     echo " sed: $(sed --version 2>&1 | head -n1)"
     echo " mktemp: $(mktemp --version 2>&1 | head -n1)"
   fi
   echo " grep: $(grep --version 2>&1 | head -n1)"
-  echo " diff: $(diff --version 2>&1 | head -n1)"
+  if [[ $OSTYPE = MirBSD ]]; then
+    echo " diff: BSD base system version"
+  else
+    echo " diff: $(diff --version 2>&1 | head -n1)"
+  fi
   echo " openssl: $("${OPENSSL}" version 2>&1)"
 
   exit 0


### PR DESCRIPTION
basically only --version output without warnings, although sed(1) on MirBSD supports only basic RE (cf. PR #618) and MirBSD comes with only mksh (cf. PR #617) out of the box