### PR TITLE
Default BASEDIR to /etc if installed to /usr/bin

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -164,6 +164,11 @@ load_config() {
     BASEDIR="$(dirname "${CONFIG}")"
     # shellcheck disable=SC1090
     . "${CONFIG}"
+  elif [[ -e /usr/bin/dehydrated ]]; then
+    BASEDIR=/etc/dehydrated
+    echo "#" >&2
+    echo "# !! WARNING !! No main config file found, using default config!" >&2
+    echo "#" >&2
   else
     _exiterr "Specified config file doesn't exist."
   fi


### PR DESCRIPTION
This would simplify package installation with the following layout: https://paste.xinu.at/y55Udx/

If you're willing to accept this change, perhaps a more tailored warning should be used here.