### PR TITLE
Split long lines in domain.txt

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1195,7 +1195,14 @@ command_sign_domains() {
   # Generate certificates for all domains found in domains.txt. Check if existing certificate are about to expire
   ORIGIFS="${IFS}"
   IFS=$'\n'
-  for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
+  line=''
+  for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
+    if [[ "${part: -1}" == '\' ]]; then
+      line="${line}${part:0:-1}"
+      continue
+    else
+      line="${line}${part}"
+    fi
     reset_configvars
     IFS="${ORIGIFS}"
     alias="$(grep -Eo '>[^ ]+' <<< "${line}" || true)"
@@ -1206,6 +1213,7 @@ command_sign_domains() {
     domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
     morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
     [ ${aliascount} -lt 1 ] && alias="${domain}" || alias="${alias#>}"
+    line=''
     export alias
 
     if [[ -z "${morenames}" ]];then

--- a/dehydrated
+++ b/dehydrated
@@ -1197,7 +1197,7 @@ command_sign_domains() {
   IFS=$'\n'
   line=''
   for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
-    if [[ "${part: -2}" == ' \' ]]; then
+    if [[ "${part: -1}" == '\' ]]; then
       line="${line}${part:0:-1}"
       continue
     else

--- a/dehydrated
+++ b/dehydrated
@@ -1197,7 +1197,7 @@ command_sign_domains() {
   IFS=$'\n'
   line=''
   for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
-    if [[ "${part: -1}" == '\' ]]; then
+    if [[ "${part: -2}" == ' \' ]]; then
       line="${line}${part:0:-1}"
       continue
     else


### PR DESCRIPTION
I have some sub-domains aliases preceded with an uuid and I'd like to split and indent them.

```
draft.example.com \
  1bd70e60-2c43-416b-aaff-c2429ea5a0d0.draft.example.com \
  1eab8b9b-5b6e-4dd9-988d-18e7af1b31e8.draft.example.com \
  2f1b79e7-8d85-4c74-a481-9775350c7c35.draft.example.com \
  40a8d208-188d-45b7-b4e8-763d42cedea3.draft.example.com \
  464497eb-de18-44e9-9783-5e53f2d7d679.draft.example.com \
  # comments and empty lines possible
  
  60ff37f4-4d9a-46f1-86c6-f38cd6bcd639.draft.example.com \
  62e14bbe-a924-4118-bcf6-13f5154ad38f.draft.example.com \
  6530cefa-c08c-4130-b372-567d5276c6ae.draft.example.com \
  67fe21dc-7177-4d2e-b2d7-374adbff6d50.draft.example.com \
  748597fe-2354-4976-8397-5047f91c9570.draft.example.com \
  887b453d-c628-4ed7-a916-542317879361.draft.example.com \
  a062f957-993d-48b4-838b-9c46ea0739e2.draft.example.com \
  a4f06559-3170-44fc-ad83-efb331d28a07.draft.example.com \
  ab4a037a-129e-49f4-87f2-06c70cecdaf5.draft.example.com \
  bb157bb9-c2a0-43dd-ba98-d8597d05e3d8.draft.example.com \
  e238f54c-9ade-41c2-b86a-38ab3bc6782d.draft.example.com \
  e2f9545f-6e5b-466a-bcd7-de1fa2388570.draft.example.com \
  f69d425a-82cc-421a-86a1-4bfbe6ce0c05.draft.example.com \
  f7e539ad-e384-430e-915e-b605e3d68a5d.draft.example.com \
  fde9056f-d280-45ca-938a-1f29cdc3e711.draft.example.com
```
