### PR TITLE
Split long lines in domains.txt (revised)

### DIFF
--- a/dehydrated
+++ b/dehydrated
@@ -1195,7 +1195,14 @@ command_sign_domains() {
   # Generate certificates for all domains found in domains.txt. Check if existing certificate are about to expire
   ORIGIFS="${IFS}"
   IFS=$'\n'
-  for line in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
+  line=''
+  for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
+    if [[ "${part: -1}" == '\' ]]; then
+      line="${line}${part:0:-1}"
+      continue
+    else
+      line="${line}${part}"
+    fi
     reset_configvars
     IFS="${ORIGIFS}"
     alias="$(grep -Eo '>[^ ]+' <<< "${line}" || true)"
@@ -1206,6 +1213,7 @@ command_sign_domains() {
     domain="$(printf '%s\n' "${line}" | cut -d' ' -f1)"
     morenames="$(printf '%s\n' "${line}" | cut -s -d' ' -f2-)"
     [ ${aliascount} -lt 1 ] && alias="${domain}" || alias="${alias#>}"
+    line=''
     export alias
 
     if [[ -z "${morenames}" ]];then

--- a/dehydrated
+++ b/dehydrated
@@ -1196,13 +1196,15 @@ command_sign_domains() {
   ORIGIFS="${IFS}"
   IFS=$'\n'
   line=''
-  for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
+  for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' -e 's/[[:space:]]+\\/\\/'); do
     if [[ "${part: -1}" == '\' ]]; then
-      line="${line}${part:0:-1}"
+      [[ "${part:0:1}" != '#' ]] && line="${line} ${part:0:-1}"
       continue
-    else
-      line="${line}${part}"
+    elif [[ "${part:0:1}" != '#' ]]; then
+      line="${line} ${part}"
     fi
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    line="${line:1}"
     reset_configvars
     IFS="${ORIGIFS}"
     alias="$(grep -Eo '>[^ ]+' <<< "${line}" || true)"

--- a/dehydrated
+++ b/dehydrated
@@ -1197,7 +1197,7 @@ command_sign_domains() {
   IFS=$'\n'
   line=''
   for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
-    if [[ "${part: -2}" == ' \' ]]; then
+    if [[ "${part: -1}" == '\' ]]; then
       line="${line}${part:0:-1}"
       continue
     else

--- a/dehydrated
+++ b/dehydrated
@@ -1197,7 +1197,7 @@ command_sign_domains() {
   IFS=$'\n'
   line=''
   for part in $(<"${DOMAINS_TXT}" tr -d '\r' | awk '{print tolower($0)}' | _sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g' -e 's/[[:space:]]+/ /g' -e 's/([^ ])>/\1 >/g' -e 's/> />/g' | (grep -vE '^(#|$)' || true)); do
-    if [[ "${part: -1}" == '\' ]]; then
+    if [[ "${part: -2}" == ' \' ]]; then
       line="${line}${part:0:-1}"
       continue
     else


### PR DESCRIPTION
According to your comment (https://github.com/lukas2511/dehydrated/pull/642#issuecomment-521625332) I revised my modifications.

There is a script to test the parsing of domains.txt at https://gist.github.com/redneck-f25/51ba79d0d3ef8a43a2eacffb672fd9d2.

Since many NAS- and Administration-Systems (e.g. Synology Diskstation and Plesk) have a plugin for LE for "simple" configurations it is the task of Dehydrated (which is great, btw) to handle more comlicated situations.

Thanks for your great work.

# example domains.txt
draft.example.com alias.example.com
draft1.example.com\
alias1.draft1.example.com\
# disabled: alias2.draft1.example.com\
alias3.draft1.example.com\

draft2.example.com \
  alias1.draft2.example.com \
  alias2.draft2.example.com \
  # disabled: alias3.draft2.example.com
draft3.example.com                  \
  alias1.draft3.example.com      \
  alias2.draft3.example.com      \
  # disabled: alias3.draft3.example.com
# end of domains.txt
